### PR TITLE
feat: add continuity engine, manuscript import, and PR automation templates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "story-skills",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A suite of cross-referenced skills and CLI maintenance tools for end-to-end story writing powered by markdown. Covers story initialization, character management, worldbuilding, plot structure, chapter writing, revision, validation, reporting, indexing, word counts, and manuscript export.",
   "author": {
     "name": "Daniel Dewhurst"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "story-skills",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A suite of cross-referenced skills and CLI maintenance tools for end-to-end story writing powered by markdown. Covers story initialization, character management, worldbuilding, plot structure, chapter writing, revision, validation, reporting, indexing, word counts, and manuscript export.",
   "author": {
     "name": "Daniel Dewhurst",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Story Skills gives agents a shared project format for fiction: a story bible, character files, worldbuilding notes, factions, artifacts, plot arcs, scene state, continuity questions, promises/payoffs, timelines, and chapter drafts. Everything is plain markdown with YAML frontmatter, packaged as standard Agent Skills with Codex and Claude Code plugin support.
 
+The companion CLI treats the story bible as a checkable contract: a **continuity engine** catches dead characters walking, payoffs that land before their setup, unfired Chekhov guns, and stale story state — deterministically, before a reader ever could.
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-SKILL.md-blue)](https://agentskills.io)
 [![Codex](https://img.shields.io/badge/Codex-plugin-10A37F)](https://developers.openai.com/codex)
@@ -39,6 +41,26 @@ bunx skills add danjdewhurst/story-skills
 ```
 
 Then ask **"Start a new story"** to scaffold the project.
+
+## 🔎 The Continuity Engine
+
+Long-range consistency is the thing language models are worst at and prompts cannot fix. Story Skills makes it deterministic: character deaths, promises/payoffs, open questions, scene casts, and durable knowledge/object state live in frontmatter, and `story continuity` treats contradictions like a compiler treats type errors.
+
+[`examples/the-unraveled-thread/`](examples/the-unraveled-thread/) is a deliberately broken mystery. It passes `story validate` and `story links` cleanly — every file is well-formed — but the story itself doesn't hold together:
+
+```text
+$ story continuity examples/the-unraveled-thread
+Continuity check failed: 4 errors, 3 warnings
+error: chapters/chapter-04.md lists edran-vale, who died in chapter-02; move posthumous appearances to mentions
+error: continuity/promises/the-broken-compass.md pays off in chapter-02 before it is planted in chapter-03
+error: continuity/questions/who-burned-the-mill.md resolves in chapter-02 before it is introduced in chapter-03
+error: continuity/state.md knowledge-state[0] references missing chapter chapter-05
+warning: chapters/chapter-03.md POV character nessa-thorn is not listed in characters
+warning: continuity/promises/the-sealed-letter.md was planted in chapter-01, 3 chapters ago, and has no payoff yet
+warning: continuity/state.md object-state[0] status active conflicts with worldbuilding/artifacts/vales-compass.md status destroyed
+```
+
+These findings are exact, file-addressed, and reproducible — CI asserts them on every commit. Intentional flashbacks and posthumous appearances stay legal via the chapter `mentions` field. `story doctor` and `story next` fold the same checks into prioritized repair actions.
 
 ## ✍️ Highly Recommended: Better Writing
 
@@ -225,7 +247,7 @@ For non-agent use:
 | **plot-structure** | Plans arcs with structures like three-act, hero's journey, Save the Cat, and kishotenketsu | *"Create a plot arc"* |
 | **chapter-writing** | Drafts chapters through an outline-first workflow that pulls from story context | *"Write the next chapter"* |
 | **revision-continuity** | Revises drafts, audits continuity, and keeps character state, timeline, and arc changes consistent | *"Continuity-check chapter 3"* |
-| **story-maintenance** | Runs deterministic CLI checks for validation, reports, indexing, links, word counts, and export | *"Validate my story project"* |
+| **story-maintenance** | Runs deterministic CLI checks for validation, continuity, reports, indexing, links, word counts, import, and export | *"Validate my story project"* |
 
 For stronger prose, pair **chapter-writing** with [**better-writing**](https://github.com/forjd/better-writing).
 
@@ -253,6 +275,8 @@ The CLI is for deterministic maintenance only. Agents should write story content
 | `story reindex [path]` | Rebuild registry tables from the current markdown files |
 | `story wordcount [path] --write` | Count chapter prose and update chapter frontmatter plus the chapter registry |
 | `story links [path]` | Check character, location, chapter, and arc cross-references/backlinks |
+| `story continuity [path]` | Check deterministic continuity contracts: deaths, promises/payoffs, questions, casts, and durable state |
+| `story import draft.md --title "The Lost Coast"` | Split an existing manuscript into a new story project and suggest entity candidates |
 | `story report [path] --actionable` | Summarize inventory and optionally include next actions |
 | `story next [path]` | Recommend the next deterministic writing or maintenance actions |
 | `story doctor [path]` | Show health checks with actionable repair steps |
@@ -277,6 +301,25 @@ bun run build:fallback
 bun run check:fallback
 node skills/story-maintenance/scripts/story.js --help
 ```
+
+## 🤖 Write A Book Via Pull Requests
+
+A story project with deterministic checks is a story project an agent can advance unattended. The [`templates/github/`](templates/github/) workflows turn a story repository into a self-drafting book:
+
+- [`story-checks.yml`](templates/github/story-checks.yml) runs `story validate`, `story links`, and `story continuity` on every push and pull request, so a chapter PR cannot merge with a continuity contradiction.
+- [`draft-next-chapter.yml`](templates/github/draft-next-chapter.yml) runs [Claude Code](https://github.com/anthropics/claude-code-action) on a schedule: it asks `story next` for the next deterministic action, drafts the next chapter with the chapter-writing skill, updates scene records and continuity state, runs the maintenance checks, and opens a pull request for review.
+
+Copy both files into `.github/workflows/` in the repository that holds your story project, add an `ANTHROPIC_API_KEY` secret, and review one chapter PR per morning.
+
+## 📥 Import An Existing Manuscript
+
+Most writers don't start from a blank page. `story import` reverse-engineers a Story Skills project from work in progress:
+
+```shell
+story import draft.md --title "The Lost Coast" --genre mystery
+```
+
+It splits the manuscript on chapter headings (or imports a directory of chapter files), creates the full project layout with accurate word counts and registries, and prints recurring proper-name candidates so an agent can follow up with `story add character` and `story add location` to build out the bible.
 
 ## 📁 Project Structure
 
@@ -328,7 +371,8 @@ Every story element is a markdown file with YAML frontmatter. The skills cross-r
 
 - Read [**The Cormorant Tide**](https://github.com/danjdewhurst/the-cormorant-tide), a full story project generated with Story Skills.
 - Explore [`examples/the-last-ember/`](examples/the-last-ember/) for a complete fantasy example: three characters, two locations, a magic system, a plot arc with foreshadowing, and a drafted first chapter.
-- Explore [`examples/harbor-of-second-light/`](examples/harbor-of-second-light/) for a near-future coastal mystery example with memory technology, a posthumous witness arc, and a drafted first chapter.
+- Explore [`examples/harbor-of-second-light/`](examples/harbor-of-second-light/) for a near-future coastal mystery example with memory technology, a posthumous witness arc, populated continuity state, and a drafted first chapter.
+- Explore [`examples/the-unraveled-thread/`](examples/the-unraveled-thread/) for a deliberately broken project that demonstrates every class of finding the continuity engine reports.
 
 ## 🚢 Releasing
 

--- a/docs/first-20-minutes.md
+++ b/docs/first-20-minutes.md
@@ -63,11 +63,12 @@ story wordcount . --write
 story reindex .
 story links .
 story validate .
+story continuity .
 story next .
 story doctor .
 ```
 
-Use `story next .` before a drafting session. Use `story doctor .` when something feels inconsistent or stale.
+Use `story next .` before a drafting session. Use `story doctor .` when something feels inconsistent or stale. Use `story continuity .` after every chapter to catch contradictions - dead characters reappearing, payoffs landing before their setup, stale story state - before a reader does.
 
 ## 6. Build The Manuscript
 

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -33,6 +33,7 @@ glossary/terms/
 - Registries are deterministic and rebuilt with `story reindex .`.
 - Chapter prose word counts are recalculated with `story wordcount . --write`.
 - Cross-reference integrity is checked with `story links .`.
+- Continuity contracts (deaths, promises/payoffs, questions, casts, durable state) are checked with `story continuity .`.
 
 ## Entity Frontmatter
 
@@ -45,6 +46,8 @@ Required: `title`, `schema-version`, `genre`, `status`, `themes`, `pov`, `tense`
 Required: `name`, `role`, `status`.
 
 Optional lists: `aliases`, `relationships`, `locations`, `tags`.
+
+Optional scalar: `died-in`, the chapter id in which the character dies on the page. Set it together with `status: deceased`; `story continuity` then errors on appearances in later chapters. Characters who died before chapter 1 should use `status: deceased` without `died-in`.
 
 ### Worldbuilding
 
@@ -60,13 +63,21 @@ Arcs require `name`, `type`, and `status`; they may list `characters`, `themes`,
 
 ### Chapters And Scenes
 
-Chapters require `title`, `number`, and `status`; optional reference lists are `locations`, `characters`, and `arcs-advanced`.
+Chapters require `title`, `number`, and `status`; optional reference lists are `locations`, `characters`, `mentions`, and `arcs-advanced`.
 
-Scenes require `title`, `chapter`, `scene`, and `status`. Scenes carry machine-readable continuity fields: `pov`, `location`, `characters`, `arcs-advanced`, and `state-changes`.
+Scenes require `title`, `chapter`, `scene`, and `status`. Scenes carry machine-readable continuity fields: `pov`, `location`, `characters`, `mentions`, `arcs-advanced`, and `state-changes`.
+
+`characters` means present in-scene. `mentions` means referenced, remembered, recorded, or seen in flashback; deceased characters may appear there without triggering continuity errors.
 
 ### Continuity
 
 `continuity/state.md` stores `current-chapter`, `character-state`, `object-state`, and `knowledge-state`.
+
+State entries are lists of mappings checked by `story continuity`:
+
+- `character-state` entries reference an existing `character` and optionally a `location`, plus free-form `physical`, `emotional`, and `knowledge` notes.
+- `object-state` entries reference an existing `artifact`, an optional `owner` (character or faction), an optional `location`, and a `status` that must agree with the artifact file.
+- `knowledge-state` entries reference an existing `character`, a non-empty `knows` fact, and an optional `learned-in` chapter id.
 
 Questions require `title` and `status`; optional chapter references are `introduced` and `resolved`.
 

--- a/examples/harbor-of-second-light/chapters/chapter-01.md
+++ b/examples/harbor-of-second-light/chapters/chapter-01.md
@@ -7,6 +7,7 @@ locations:
   - port-kestrel
 characters:
   - mara-quill
+mentions:
   - theo-quill
 arcs-advanced:
   - the-drowned-witness

--- a/examples/harbor-of-second-light/continuity/promises/_index.md
+++ b/examples/harbor-of-second-light/continuity/promises/_index.md
@@ -9,4 +9,4 @@ story: harbor-of-second-light
 
 | Promise | Status | Planted | File |
 |---------|--------|---------|------|
-| *No promises yet* | | | |
+| The Bell Failsafe | planted | chapter-01 | [the-bell-failsafe](the-bell-failsafe.md) |

--- a/examples/harbor-of-second-light/continuity/promises/the-bell-failsafe.md
+++ b/examples/harbor-of-second-light/continuity/promises/the-bell-failsafe.md
@@ -1,0 +1,25 @@
+---
+title: The Bell Failsafe
+status: planted
+planted: chapter-01
+payoff: ""
+arcs:
+  - the-drowned-witness
+characters:
+  - mara-quill
+  - theo-quill
+---
+
+# The Bell Failsafe
+
+## Setup
+
+The bell under Bellwether Reef rang on its own when the storm cracked the sealed chamber. Theo built it as a failsafe: if the bell rings, the archive is live again.
+
+## Payoff
+
+A later chapter must reveal what the failsafe was meant to summon - and who else heard the bell.
+
+## Tracking Notes
+
+Keep planted and payoff chapters current.

--- a/examples/harbor-of-second-light/continuity/questions/_index.md
+++ b/examples/harbor-of-second-light/continuity/questions/_index.md
@@ -9,4 +9,4 @@ story: harbor-of-second-light
 
 | Question | Status | Introduced | File |
 |----------|--------|------------|------|
-| *No questions yet* | | | |
+| What Happened On Blackout Night | open | chapter-01 | [what-happened-on-blackout-night](what-happened-on-blackout-night.md) |

--- a/examples/harbor-of-second-light/continuity/questions/what-happened-on-blackout-night.md
+++ b/examples/harbor-of-second-light/continuity/questions/what-happened-on-blackout-night.md
@@ -1,0 +1,26 @@
+---
+title: What Happened On Blackout Night
+status: open
+introduced: chapter-01
+resolved: ""
+characters:
+  - mara-quill
+  - theo-quill
+  - ilya-venn
+---
+
+# What Happened On Blackout Night
+
+## Question
+
+Theo's recording says the Afterimage Archive was active during the Blackout Night. Twelve residents died and Theo took the blame. What was the archive doing, and on whose orders?
+
+## Evidence
+
+- The sealed chamber under Bellwether Reef carries Harbor Authority plating.
+- Theo's recording was hidden before his death and addressed to Mara.
+- Councillor Venn controls the archive-keeper appointments.
+
+## Resolution Plan
+
+Resolve once Mara confronts Venn with the lantern's contents.

--- a/examples/harbor-of-second-light/continuity/state.md
+++ b/examples/harbor-of-second-light/continuity/state.md
@@ -1,32 +1,48 @@
 ---
 type: continuity-state
 story: harbor-of-second-light
-current-chapter: 0
-character-state: []
-object-state: []
-knowledge-state: []
+current-chapter: 1
+character-state:
+  - character: mara-quill
+    location: port-kestrel
+    physical: unharmed after the reef dive
+    emotional: shaken but resolved
+  - character: ilya-venn
+    location: port-kestrel
+    physical: unharmed
+    emotional: unaware the chamber is open
+object-state:
+  - artifact: archive-lantern
+    owner: mara-quill
+    location: port-kestrel
+    status: hidden
+knowledge-state:
+  - character: mara-quill
+    knows: the Afterimage Archive was active during the Blackout Night
+    learned-in: chapter-01
 ---
 
 # Continuity State
 
 ## Current Story State
 
-Track facts that must carry forward between chapters.
+Mara has recovered the archive lantern from Bellwether Reef and is hiding it on Dock Six. The Harbor Authority does not yet know the sealed chamber is open.
 
 ## Character State
 
 | Character | Location | Physical State | Emotional State | Knowledge |
 |-----------|----------|----------------|-----------------|-----------|
-| *No state entries yet* | | | | |
+| mara-quill | port-kestrel | Unharmed after the reef dive | Shaken but resolved | Knows the archive ran on Blackout Night |
+| ilya-venn | port-kestrel | Unharmed | Unaware the chamber is open | Believes the chamber is still sealed |
 
 ## Object State
 
 | Artifact | Owner | Location | Status |
 |----------|-------|----------|--------|
-| *No object state entries yet* | | | |
+| archive-lantern | mara-quill | port-kestrel | hidden |
 
 ## Knowledge State
 
 | Character | Knows | Learned In |
 |-----------|-------|------------|
-| *No knowledge entries yet* | | |
+| mara-quill | The Afterimage Archive was active during the Blackout Night | chapter-01 |

--- a/examples/harbor-of-second-light/scenes/chapter-01-scene-01.md
+++ b/examples/harbor-of-second-light/scenes/chapter-01-scene-01.md
@@ -6,6 +6,7 @@ pov: mara-quill
 location: bellwether-reef
 characters:
   - mara-quill
+mentions:
   - theo-quill
 arcs-advanced:
   - the-drowned-witness

--- a/examples/harbor-of-second-light/worldbuilding/artifacts/archive-lantern.md
+++ b/examples/harbor-of-second-light/worldbuilding/artifacts/archive-lantern.md
@@ -2,8 +2,8 @@
 name: "Archive Lantern"
 type: technology
 status: hidden
-owner: harbor-council
-location: bellwether-reef
+owner: mara-quill
+location: port-kestrel
 tags:
   - memory-storage
   - evidence

--- a/examples/the-last-ember/continuity/state.md
+++ b/examples/the-last-ember/continuity/state.md
@@ -1,7 +1,7 @@
 ---
 type: continuity-state
 story: the-last-ember
-current-chapter: 0
+current-chapter: 1
 character-state: []
 object-state: []
 knowledge-state: []

--- a/examples/the-unraveled-thread/chapters/_index.md
+++ b/examples/the-unraveled-thread/chapters/_index.md
@@ -1,0 +1,17 @@
+---
+type: chapter-registry
+story: the-unraveled-thread
+---
+
+# Chapters
+
+## Registry
+
+| # | Title | POV | Status | Word Count | File |
+|---|-------|-----|--------|------------|------|
+| 1 | The Ledger in the Ash | jonas-reed | draft | 34 | [chapter-01](chapter-01.md) |
+| 2 | The Millpond | jonas-reed | draft | 31 | [chapter-02](chapter-02.md) |
+| 3 | The Dry Side of Mill Row | nessa-thorn | draft | 24 | [chapter-03](chapter-03.md) |
+| 4 | The Lock Gate | jonas-reed | draft | 22 | [chapter-04](chapter-04.md) |
+
+## Total Word Count: 111

--- a/examples/the-unraveled-thread/chapters/chapter-01.md
+++ b/examples/the-unraveled-thread/chapters/chapter-01.md
@@ -1,0 +1,30 @@
+---
+title: "The Ledger in the Ash"
+number: 1
+pov: jonas-reed
+locations:
+  - the-mill-row
+characters:
+  - jonas-reed
+  - edran-vale
+arcs-advanced:
+  - the-ledger-trail
+status: draft
+word-count: 34
+---
+
+
+# Chapter 1: The Ledger in the Ash
+
+## Outline
+
+1. Opening beat
+2. Escalation
+3. Turn or decision
+
+---
+
+## Chapter Text
+
+Jonas Reed found the ledger in the ash two days after the mill burned. Edran Vale's handwriting filled every margin, and a sealed letter was pinned inside the back cover, addressed to no one.
+

--- a/examples/the-unraveled-thread/chapters/chapter-02.md
+++ b/examples/the-unraveled-thread/chapters/chapter-02.md
@@ -1,0 +1,30 @@
+---
+title: "The Millpond"
+number: 2
+pov: jonas-reed
+locations:
+  - the-mill-row
+characters:
+  - jonas-reed
+  - edran-vale
+arcs-advanced:
+  - the-ledger-trail
+status: draft
+word-count: 31
+---
+
+
+# Chapter 2: The Millpond
+
+## Outline
+
+1. Opening beat
+2. Escalation
+3. Turn or decision
+
+---
+
+## Chapter Text
+
+Edran Vale was pulled from the millpond on a grey Tuesday. Jonas stood on the bank with the ledger under his coat and said nothing to the constable about the letter.
+

--- a/examples/the-unraveled-thread/chapters/chapter-03.md
+++ b/examples/the-unraveled-thread/chapters/chapter-03.md
@@ -1,0 +1,29 @@
+---
+title: "The Dry Side of Mill Row"
+number: 3
+pov: nessa-thorn
+locations:
+  - the-mill-row
+characters:
+  - jonas-reed
+arcs-advanced:
+  - the-ledger-trail
+status: draft
+word-count: 24
+---
+
+
+# Chapter 3: The Dry Side of Mill Row
+
+## Outline
+
+1. Opening beat
+2. Escalation
+3. Turn or decision
+
+---
+
+## Chapter Text
+
+Nessa Thorn watched the Reed cottage from the dry side of Mill Row. Jonas burned a page that night. She wrote down which one.
+

--- a/examples/the-unraveled-thread/chapters/chapter-04.md
+++ b/examples/the-unraveled-thread/chapters/chapter-04.md
@@ -1,0 +1,30 @@
+---
+title: "The Lock Gate"
+number: 4
+pov: jonas-reed
+locations:
+  - the-mill-row
+characters:
+  - jonas-reed
+  - edran-vale
+arcs-advanced:
+  - the-ledger-trail
+status: draft
+word-count: 22
+---
+
+
+# Chapter 4: The Lock Gate
+
+## Outline
+
+1. Opening beat
+2. Escalation
+3. Turn or decision
+
+---
+
+## Chapter Text
+
+Jonas met Edran at the lock gate at midnight, and Edran told him which page mattered. The fog took both their voices.
+

--- a/examples/the-unraveled-thread/characters/_index.md
+++ b/examples/the-unraveled-thread/characters/_index.md
@@ -1,0 +1,22 @@
+---
+type: character-registry
+story: the-unraveled-thread
+---
+
+# Characters
+
+## Registry
+
+| Name | Role | Status | File |
+|------|------|--------|------|
+| Edran Vale | supporting | deceased | [edran-vale](edran-vale.md) |
+| Jonas Reed | protagonist | alive | [jonas-reed](jonas-reed.md) |
+| Nessa Thorn | antagonist | alive | [nessa-thorn](nessa-thorn.md) |
+
+## Relationship Map
+
+*No relationships defined yet.*
+
+## Family Trees
+
+*No family trees defined yet.*

--- a/examples/the-unraveled-thread/characters/edran-vale.md
+++ b/examples/the-unraveled-thread/characters/edran-vale.md
@@ -1,0 +1,45 @@
+---
+name: Edran Vale
+role: supporting
+status: deceased
+died-in: chapter-02
+aliases: []
+relationships: []
+locations: []
+tags: []
+arc: ""
+---
+
+# Edran Vale
+
+## Appearance
+
+Add physical details that matter on the page.
+
+## Personality & Traits
+
+Add behavior, temperament, habits, and contradictions.
+
+## Backstory
+
+Add only story-relevant history.
+
+## Motivations & Goals
+
+External want, internal need, and the conflict between them.
+
+## Voice & Speech Patterns
+
+Add 2-3 example lines.
+
+## Character Arc
+
+- **Starting state:**
+- **Key turning points:**
+- **Ending state:**
+
+## Timeline
+
+| When | Event | Relevance |
+|------|-------|-----------|
+| | | |

--- a/examples/the-unraveled-thread/characters/jonas-reed.md
+++ b/examples/the-unraveled-thread/characters/jonas-reed.md
@@ -1,0 +1,44 @@
+---
+name: Jonas Reed
+role: protagonist
+status: alive
+aliases: []
+relationships: []
+locations: []
+tags: []
+arc: ""
+---
+
+# Jonas Reed
+
+## Appearance
+
+Add physical details that matter on the page.
+
+## Personality & Traits
+
+Add behavior, temperament, habits, and contradictions.
+
+## Backstory
+
+Add only story-relevant history.
+
+## Motivations & Goals
+
+External want, internal need, and the conflict between them.
+
+## Voice & Speech Patterns
+
+Add 2-3 example lines.
+
+## Character Arc
+
+- **Starting state:**
+- **Key turning points:**
+- **Ending state:**
+
+## Timeline
+
+| When | Event | Relevance |
+|------|-------|-----------|
+| | | |

--- a/examples/the-unraveled-thread/characters/nessa-thorn.md
+++ b/examples/the-unraveled-thread/characters/nessa-thorn.md
@@ -1,0 +1,44 @@
+---
+name: Nessa Thorn
+role: antagonist
+status: alive
+aliases: []
+relationships: []
+locations: []
+tags: []
+arc: ""
+---
+
+# Nessa Thorn
+
+## Appearance
+
+Add physical details that matter on the page.
+
+## Personality & Traits
+
+Add behavior, temperament, habits, and contradictions.
+
+## Backstory
+
+Add only story-relevant history.
+
+## Motivations & Goals
+
+External want, internal need, and the conflict between them.
+
+## Voice & Speech Patterns
+
+Add 2-3 example lines.
+
+## Character Arc
+
+- **Starting state:**
+- **Key turning points:**
+- **Ending state:**
+
+## Timeline
+
+| When | Event | Relevance |
+|------|-------|-----------|
+| | | |

--- a/examples/the-unraveled-thread/continuity/promises/_index.md
+++ b/examples/the-unraveled-thread/continuity/promises/_index.md
@@ -1,0 +1,13 @@
+---
+type: promise-registry
+story: the-unraveled-thread
+---
+
+# Promises And Payoffs
+
+## Registry
+
+| Promise | Status | Planted | File |
+|---------|--------|---------|------|
+| The Broken Compass | paid-off | chapter-03 | [the-broken-compass](the-broken-compass.md) |
+| The Sealed Letter | planted | chapter-01 | [the-sealed-letter](the-sealed-letter.md) |

--- a/examples/the-unraveled-thread/continuity/promises/the-broken-compass.md
+++ b/examples/the-unraveled-thread/continuity/promises/the-broken-compass.md
@@ -1,0 +1,22 @@
+---
+title: The Broken Compass
+status: paid-off
+planted: chapter-03
+payoff: chapter-02
+arcs: []
+characters: []
+---
+
+# The Broken Compass
+
+## Setup
+
+What is promised to the reader.
+
+## Payoff
+
+How the story should answer the setup.
+
+## Tracking Notes
+
+Keep planted and payoff chapters current.

--- a/examples/the-unraveled-thread/continuity/promises/the-sealed-letter.md
+++ b/examples/the-unraveled-thread/continuity/promises/the-sealed-letter.md
@@ -1,0 +1,22 @@
+---
+title: The Sealed Letter
+status: planted
+planted: chapter-01
+payoff: ""
+arcs: []
+characters: []
+---
+
+# The Sealed Letter
+
+## Setup
+
+What is promised to the reader.
+
+## Payoff
+
+How the story should answer the setup.
+
+## Tracking Notes
+
+Keep planted and payoff chapters current.

--- a/examples/the-unraveled-thread/continuity/questions/_index.md
+++ b/examples/the-unraveled-thread/continuity/questions/_index.md
@@ -1,0 +1,12 @@
+---
+type: question-registry
+story: the-unraveled-thread
+---
+
+# Continuity Questions
+
+## Registry
+
+| Question | Status | Introduced | File |
+|----------|--------|------------|------|
+| Who Burned The Mill | resolved | chapter-03 | [who-burned-the-mill](who-burned-the-mill.md) |

--- a/examples/the-unraveled-thread/continuity/questions/who-burned-the-mill.md
+++ b/examples/the-unraveled-thread/continuity/questions/who-burned-the-mill.md
@@ -1,0 +1,21 @@
+---
+title: Who Burned The Mill
+status: resolved
+introduced: chapter-03
+resolved: chapter-02
+characters: []
+---
+
+# Who Burned The Mill
+
+## Question
+
+What the reader or continuity tracker needs answered.
+
+## Evidence
+
+Known clues, constraints, and contradictions.
+
+## Resolution Plan
+
+How and when this should resolve.

--- a/examples/the-unraveled-thread/continuity/state.md
+++ b/examples/the-unraveled-thread/continuity/state.md
@@ -1,0 +1,43 @@
+---
+type: continuity-state
+story: the-unraveled-thread
+current-chapter: 4
+character-state:
+  - character: jonas-reed
+    location: the-mill-row
+    physical: smoke-scarred hands
+    emotional: cornered
+knowledge-state:
+  - character: jonas-reed
+    knows: which ledger page names the firestarter
+    learned-in: chapter-05
+object-state:
+  - artifact: vales-compass
+    owner: jonas-reed
+    location: the-mill-row
+    status: active
+---
+
+# Continuity State
+
+## Current Story State
+
+Jonas holds the ledger and one burned page of it. Nessa knows which page he burned.
+
+## Character State
+
+| Character | Location | Physical State | Emotional State | Knowledge |
+|-----------|----------|----------------|-----------------|-----------|
+| jonas-reed | the-mill-row | Smoke-scarred hands | Cornered | Holds the ledger |
+
+## Object State
+
+| Artifact | Owner | Location | Status |
+|----------|-------|----------|--------|
+| vales-compass | jonas-reed | the-mill-row | active |
+
+## Knowledge State
+
+| Character | Knows | Learned In |
+|-----------|-------|------------|
+| jonas-reed | Which ledger page names the firestarter | chapter-05 |

--- a/examples/the-unraveled-thread/glossary/_index.md
+++ b/examples/the-unraveled-thread/glossary/_index.md
@@ -1,0 +1,12 @@
+---
+type: glossary-registry
+story: the-unraveled-thread
+---
+
+# Glossary
+
+## Registry
+
+| Term | Category | File |
+|------|----------|------|
+| *No terms yet* | | |

--- a/examples/the-unraveled-thread/plot/_index.md
+++ b/examples/the-unraveled-thread/plot/_index.md
@@ -1,0 +1,23 @@
+---
+type: plot-registry
+story: the-unraveled-thread
+structure: three-act
+---
+
+# Plot Structure
+
+## Story Structure
+
+**Model:** Three-Act Structure (adjust as needed)
+
+## Arcs
+
+| Name | Type | Status | File |
+|------|------|--------|------|
+| The Ledger Trail | main | planned | [the-ledger-trail](arcs/the-ledger-trail.md) |
+
+## Theme Tracking
+
+| Theme | Arcs | Chapters |
+|-------|------|----------|
+| *No themes tracked yet* | | |

--- a/examples/the-unraveled-thread/plot/arcs/the-ledger-trail.md
+++ b/examples/the-unraveled-thread/plot/arcs/the-ledger-trail.md
@@ -1,0 +1,40 @@
+---
+name: The Ledger Trail
+type: main
+status: planned
+characters: []
+themes: []
+acts: []
+---
+
+# The Ledger Trail
+
+## Setup
+
+Initial state and inciting pressure.
+
+## Rising Action
+
+1. First escalation
+2. Second escalation
+3. Reversal or complication
+
+## Climax
+
+Decision point or highest tension.
+
+## Resolution
+
+What changes because of this arc.
+
+## Plot Points
+
+| # | Plot Point | Act | Chapter | Status | Notes |
+|---|------------|-----|---------|--------|-------|
+| 1 | | | | planned | |
+
+## Foreshadowing
+
+| Planted | Payoff | Chapter Planted | Chapter Payoff | Status |
+|---------|--------|-----------------|----------------|--------|
+| | | | | planned |

--- a/examples/the-unraveled-thread/plot/timeline.md
+++ b/examples/the-unraveled-thread/plot/timeline.md
@@ -1,0 +1,10 @@
+---
+type: timeline
+story: the-unraveled-thread
+---
+
+# Story Timeline
+
+| When | Event | Arc | Chapter |
+|------|-------|-----|---------|
+| *No events yet* | | | |

--- a/examples/the-unraveled-thread/scenes/_index.md
+++ b/examples/the-unraveled-thread/scenes/_index.md
@@ -1,0 +1,15 @@
+---
+type: scene-registry
+story: the-unraveled-thread
+---
+
+# Scenes
+
+## Registry
+
+| Chapter | Scene | Title | POV | Status | File |
+|---------|-------|-------|-----|--------|------|
+| chapter-01 | 1 | The Ash and the Ledger | jonas-reed | outline | [chapter-01-scene-01](chapter-01-scene-01.md) |
+| chapter-02 | 1 | The Millpond | jonas-reed | outline | [chapter-02-scene-01](chapter-02-scene-01.md) |
+| chapter-03 | 1 | The Dry Side of Mill Row | jonas-reed | outline | [chapter-03-scene-01](chapter-03-scene-01.md) |
+| chapter-04 | 1 | The Lock Gate | jonas-reed | outline | [chapter-04-scene-01](chapter-04-scene-01.md) |

--- a/examples/the-unraveled-thread/scenes/chapter-01-scene-01.md
+++ b/examples/the-unraveled-thread/scenes/chapter-01-scene-01.md
@@ -1,0 +1,24 @@
+---
+title: "The Ash and the Ledger"
+chapter: chapter-01
+scene: 1
+pov: jonas-reed
+location: the-mill-row
+characters:
+  - jonas-reed
+  - edran-vale
+arcs-advanced:
+  - the-ledger-trail
+status: outline
+state-changes: []
+---
+
+# Scene
+
+## Purpose
+
+What this scene changes.
+
+## Continuity Notes
+
+Character state, object state, knowledge changes, and timeline facts.

--- a/examples/the-unraveled-thread/scenes/chapter-02-scene-01.md
+++ b/examples/the-unraveled-thread/scenes/chapter-02-scene-01.md
@@ -1,0 +1,24 @@
+---
+title: "The Millpond"
+chapter: chapter-02
+scene: 1
+pov: jonas-reed
+location: the-mill-row
+characters:
+  - jonas-reed
+  - edran-vale
+arcs-advanced:
+  - the-ledger-trail
+status: outline
+state-changes: []
+---
+
+# Scene
+
+## Purpose
+
+What this scene changes.
+
+## Continuity Notes
+
+Character state, object state, knowledge changes, and timeline facts.

--- a/examples/the-unraveled-thread/scenes/chapter-03-scene-01.md
+++ b/examples/the-unraveled-thread/scenes/chapter-03-scene-01.md
@@ -1,0 +1,23 @@
+---
+title: "The Dry Side of Mill Row"
+chapter: chapter-03
+scene: 1
+pov: jonas-reed
+location: the-mill-row
+characters:
+  - jonas-reed
+arcs-advanced:
+  - the-ledger-trail
+status: outline
+state-changes: []
+---
+
+# Scene
+
+## Purpose
+
+What this scene changes.
+
+## Continuity Notes
+
+Character state, object state, knowledge changes, and timeline facts.

--- a/examples/the-unraveled-thread/scenes/chapter-04-scene-01.md
+++ b/examples/the-unraveled-thread/scenes/chapter-04-scene-01.md
@@ -1,0 +1,23 @@
+---
+title: "The Lock Gate"
+chapter: chapter-04
+scene: 1
+pov: jonas-reed
+location: the-mill-row
+characters:
+  - jonas-reed
+arcs-advanced:
+  - the-ledger-trail
+status: outline
+state-changes: []
+---
+
+# Scene
+
+## Purpose
+
+What this scene changes.
+
+## Continuity Notes
+
+Character state, object state, knowledge changes, and timeline facts.

--- a/examples/the-unraveled-thread/story.md
+++ b/examples/the-unraveled-thread/story.md
@@ -1,0 +1,26 @@
+---
+title: The Unraveled Thread
+schema-version: 2
+genre: mystery
+sub-genre: village-noir
+setting-era: 1920s
+status: drafting
+themes:
+  - guilt
+  - small-town secrets
+pov: third-person-limited
+tense: past
+---
+
+# The Unraveled Thread
+
+## Synopsis
+
+After the mill fire, Jonas Reed inherits his dead partner's ledger and realizes the fire was no accident. Every page he deciphers makes one neighbor look guiltier - and Jonas look worse.
+
+## Tone & Style
+
+Add notes on the story's voice, texture, and emotional register.
+
+## Notes
+

--- a/examples/the-unraveled-thread/worldbuilding/_index.md
+++ b/examples/the-unraveled-thread/worldbuilding/_index.md
@@ -1,0 +1,34 @@
+---
+type: world-registry
+story: the-unraveled-thread
+---
+
+# Worldbuilding
+
+## World Overview
+
+*Describe the world at a high level here.*
+
+## Locations
+
+| Name | Type | Region | File |
+|------|------|--------|------|
+| The Mill Row | District |  | [the-mill-row](locations/the-mill-row.md) |
+
+## Systems
+
+| Name | Type | File |
+|------|------|------|
+| *No systems yet* | | |
+
+## Factions
+
+| Name | Type | Status | File |
+|------|------|--------|------|
+| *No factions yet* | | | |
+
+## Artifacts
+
+| Name | Type | Status | File |
+|------|------|--------|------|
+| Vales Compass | Object | destroyed | [vales-compass](artifacts/vales-compass.md) |

--- a/examples/the-unraveled-thread/worldbuilding/artifacts/vales-compass.md
+++ b/examples/the-unraveled-thread/worldbuilding/artifacts/vales-compass.md
@@ -1,0 +1,26 @@
+---
+name: Vales Compass
+type: object
+status: destroyed
+owner: edran-vale
+location: ""
+tags: []
+---
+
+# Vales Compass
+
+## Description
+
+What it is and how readers recognize it.
+
+## Function
+
+What it can do, cannot do, costs, and constraints.
+
+## History
+
+Where it came from and why it matters.
+
+## Current State
+
+Who has it, where it is, and what changed recently.

--- a/examples/the-unraveled-thread/worldbuilding/locations/the-mill-row.md
+++ b/examples/the-unraveled-thread/worldbuilding/locations/the-mill-row.md
@@ -1,0 +1,32 @@
+---
+name: The Mill Row
+type: district
+region: ""
+population: ""
+controlled-by: ""
+notable-characters: []
+tags: []
+status: unknown
+---
+
+# The Mill Row
+
+## Description
+
+Add sensory details and first impressions.
+
+## History
+
+Add relevant history.
+
+## Culture & Customs
+
+Add social norms, rituals, or local patterns.
+
+## Notable Features
+
+Add landmarks or practical story elements.
+
+## Current State
+
+Add what is true at the current story moment.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "story-skills",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Agent skills and a companion CLI for planning, tracking, and drafting fiction in markdown.",
   "type": "module",
   "packageManager": "bun@1.3.14",

--- a/schemas/story.schema.json
+++ b/schemas/story.schema.json
@@ -56,6 +56,7 @@
         "name": { "type": "string" },
         "role": { "enum": ["protagonist", "antagonist", "supporting", "minor", "narrator", "deuteragonist"] },
         "status": { "enum": ["alive", "deceased", "unknown", "missing"] },
+        "died-in": { "type": "string" },
         "locations": { "$ref": "#/$defs/stringList" }
       }
     },
@@ -117,7 +118,10 @@
         "id": { "$ref": "#/$defs/id" },
         "title": { "type": "string" },
         "number": { "type": "integer", "minimum": 1 },
-        "status": { "enum": ["outline", "draft", "revised", "final", "complete"] }
+        "status": { "enum": ["outline", "draft", "revised", "final", "complete"] },
+        "characters": { "$ref": "#/$defs/stringList" },
+        "mentions": { "$ref": "#/$defs/stringList" },
+        "locations": { "$ref": "#/$defs/stringList" }
       }
     },
     "scene": {
@@ -128,7 +132,9 @@
         "title": { "type": "string" },
         "chapter": { "$ref": "#/$defs/id" },
         "scene": { "type": "integer", "minimum": 1 },
-        "status": { "enum": ["outline", "draft", "revised", "final", "complete"] }
+        "status": { "enum": ["outline", "draft", "revised", "final", "complete"] },
+        "characters": { "$ref": "#/$defs/stringList" },
+        "mentions": { "$ref": "#/$defs/stringList" }
       }
     },
     "question": {

--- a/scripts/check-examples.js
+++ b/scripts/check-examples.js
@@ -2,12 +2,30 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { computeWordCounts, validateLinks, validateProject } from "../src/story.js";
+import { checkProjectContinuity, computeWordCounts, validateLinks, validateProject } from "../src/story.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const examplesRoot = path.join(repoRoot, "examples");
 const failures = [];
 const summaries = [];
+
+// the-unraveled-thread is the showcase for `story continuity`: it must stay
+// structurally valid while producing exactly these deterministic findings.
+const EXPECTED_CONTINUITY = {
+  "the-unraveled-thread": {
+    errors: [
+      "chapters/chapter-04.md lists edran-vale, who died in chapter-02; move posthumous appearances to mentions",
+      "continuity/promises/the-broken-compass.md pays off in chapter-02 before it is planted in chapter-03",
+      "continuity/questions/who-burned-the-mill.md resolves in chapter-02 before it is introduced in chapter-03",
+      "continuity/state.md knowledge-state[0] references missing chapter chapter-05"
+    ],
+    warnings: [
+      "chapters/chapter-03.md POV character nessa-thorn is not listed in characters",
+      "continuity/promises/the-sealed-letter.md was planted in chapter-01, 3 chapters ago, and has no payoff yet",
+      "continuity/state.md object-state[0] status active conflicts with worldbuilding/artifacts/vales-compass.md status destroyed"
+    ]
+  }
+};
 
 for (const name of fs.readdirSync(examplesRoot).sort()) {
   const root = path.join(examplesRoot, name);
@@ -17,11 +35,20 @@ for (const name of fs.readdirSync(examplesRoot).sort()) {
 
   const validation = validateProject(root);
   const links = validateLinks(root);
+  const continuity = checkProjectContinuity(root);
   const counts = computeWordCounts(root);
-  summaries.push(`${name}: ${counts.chapters.length} chapters, ${counts.total} words`);
+  const expected = EXPECTED_CONTINUITY[name];
+  summaries.push(`${name}: ${counts.chapters.length} chapters, ${counts.total} words, ${continuity.errors.length + continuity.warnings.length} expected continuity findings`);
 
   collectResult(name, "validate", validation);
   collectResult(name, "links", links);
+
+  if (expected) {
+    compareFindings(name, "error", expected.errors, continuity.errors);
+    compareFindings(name, "warning", expected.warnings, continuity.warnings);
+  } else {
+    collectResult(name, "continuity", continuity);
+  }
 }
 
 if (failures.length > 0) {
@@ -38,5 +65,19 @@ function collectResult(exampleName, command, result) {
 
   for (const warning of result.warnings) {
     failures.push(`${exampleName} ${command} warning: ${warning}`);
+  }
+}
+
+function compareFindings(exampleName, kind, expected, actual) {
+  for (const finding of expected) {
+    if (!actual.includes(finding)) {
+      failures.push(`${exampleName} continuity is missing expected ${kind}: ${finding}`);
+    }
+  }
+
+  for (const finding of actual) {
+    if (!expected.includes(finding)) {
+      failures.push(`${exampleName} continuity has unexpected ${kind}: ${finding}`);
+    }
   }
 }

--- a/skills/chapter-writing/references/chapter-template.md
+++ b/skills/chapter-writing/references/chapter-template.md
@@ -11,12 +11,16 @@ locations:
   - {location-kebab}
 characters:
   - {character-kebab}
+mentions:
+  - {referenced-character-kebab}
 arcs-advanced:
   - {arc-kebab}
 status: {outline|draft|revised|final}
 word-count: {N}
 ---
 ```
+
+`characters` lists characters present in the chapter's scenes. `mentions` is optional and lists characters who are only referenced, remembered, recorded, or seen in flashback - including deceased characters, so `story continuity` does not flag them as posthumous appearances.
 
 ## Outline
 

--- a/skills/character-management/references/character-template.md
+++ b/skills/character-management/references/character-template.md
@@ -8,6 +8,7 @@ name: "{Full Name}"
 role: {protagonist|antagonist|supporting|minor}
 age: {age}
 status: {alive|deceased|unknown}
+died-in: {chapter-NN}
 aliases:
   - "{Alias 1}"
 relationships:
@@ -21,6 +22,8 @@ tags:
 arc: {character-arc-theme}
 ---
 ```
+
+`died-in` is optional. Set it (with `status: deceased`) when a character dies on the page so `story continuity` can flag appearances in later chapters; leave it out for characters who died before the story begins. Posthumous appearances in flashbacks, memories, or recordings belong in chapter/scene `mentions`, not `characters`.
 
 ## Appearance
 

--- a/skills/revision-continuity/SKILL.md
+++ b/skills/revision-continuity/SKILL.md
@@ -49,14 +49,17 @@ story wordcount . --write
 story reindex .
 story links .
 story validate .
+story continuity .
 story doctor .
 ```
+
+`story continuity` deterministically checks death ordering (`died-in` vs later appearances), promise/question chapter ordering, unfired setups, POV/cast consistency, and `continuity/state.md` references. For intentional flashbacks, memories, or recordings of dead characters, list them under chapter or scene `mentions` instead of `characters`.
 
 If `story` is not installed, use `bun run story --` from this repository or the bundled `story-maintenance/scripts/story.js` fallback when available.
 
 ## Continuity Audit Checklist
 
-Check for:
+Run `story continuity .` first to collect the deterministic findings, then check for what the CLI cannot judge:
 
 - Character knowledge: no one acts on information they have not learned
 - Character state: injuries, emotions, alliances, location, and status carry forward

--- a/skills/story-init/SKILL.md
+++ b/skills/story-init/SKILL.md
@@ -14,6 +14,7 @@ Initialize a new story project with a structured markdown folder layout. Creates
 - Starting a new story, book, or fiction project
 - Setting up the folder structure for an existing story idea
 - NOT for adding to an existing story project (use the domain-specific skills instead)
+- NOT for converting an existing manuscript or chapter drafts: run `story import <source> --title "{Title}"` instead, then build out the bible from the entity candidates it prints
 
 ## Workflow
 
@@ -241,6 +242,8 @@ These conventions apply across ALL story skills:
 - **`story.md`** is the top-level bible read by all skills for context
 - **Bidirectional cross-links** - when referencing another entity, update both files
 - **Character identifiers** use the kebab-case filename without extension (e.g., `sera-voss`)
+- **Death tracking** - when a character dies on the page, set `status: deceased` and `died-in: chapter-{NN}` so `story continuity` can flag posthumous appearances
+- **`mentions` vs `characters`** - chapter and scene frontmatter lists characters present in-scene under `characters`; characters who are only referenced, remembered, recorded, or seen in flashback go under `mentions`
 - **Scene identifiers** use `chapter-{NN}-scene-{NN}` and live in `scenes/`
 - **Continuity state** lives in `continuity/state.md`, with open questions and promises tracked under `continuity/questions/` and `continuity/promises/`
 - **Markdown-first artifacts** - create and edit story content directly in the target `.md` files. Do not create project-local build scripts, generator scripts, or bulk writer scripts (for example `build-*.js`) to emit story files.

--- a/skills/story-maintenance/SKILL.md
+++ b/skills/story-maintenance/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: story-maintenance
-description: This skill should be used when the user asks to validate, reindex, repair registries, check links, count words, summarize a story project, export a manuscript, run the story CLI, or perform deterministic maintenance on a Story Skills markdown project.
+description: This skill should be used when the user asks to validate, reindex, repair registries, check links, check continuity, count words, summarize a story project, import an existing manuscript, export a manuscript, run the story CLI, or perform deterministic maintenance on a Story Skills markdown project.
 ---
 
 # Story Maintenance
 
 ## Overview
 
-Run deterministic maintenance for Story Skills projects. Use the CLI for structure validation, registry rebuilds, word counts, link checks, project reports, next-action reports, schema migration, entity helpers, and manuscript export. The creative skills still own story decisions; this skill handles mechanical consistency.
+Run deterministic maintenance for Story Skills projects. Use the CLI for structure validation, registry rebuilds, word counts, link checks, continuity checks, project reports, next-action reports, schema migration, entity helpers, manuscript import, and manuscript export. The creative skills still own story decisions; this skill handles mechanical consistency.
 
 ## CLI Access
 
@@ -30,6 +30,8 @@ story validate .
 story reindex .
 story wordcount . --write
 story links .
+story continuity .
+story import draft.md --title "Title"
 story report .
 story report . --actionable
 story next .
@@ -50,6 +52,8 @@ Use:
 - `reindex` after adding/removing/renaming characters, locations, systems, arcs, or chapters
 - `wordcount --write` after writing or revising chapters
 - `links` after changing character relationships, notable locations, arc participants, or chapter references
+- `continuity` after drafting or revising a chapter, and whenever the user asks about contradictions, dead characters appearing, unfired setups, or stale state; it deterministically checks `died-in` ordering, promise/question chapter ordering, Chekhov gaps, POV/cast consistency, and `continuity/state.md` references
+- `import` when the user has an existing manuscript or chapter drafts and wants a Story Skills project built from them; follow up by creating character and location files from the printed entity candidates
 - `report` when the user asks for project status, inventory, progress, or a quick health summary
 - `next` before a drafting session to identify the next deterministic action
 - `doctor` when the user asks what is stale, broken, or inconsistent

--- a/skills/story-maintenance/scripts/story.js
+++ b/skills/story-maintenance/scripts/story.js
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 
 // src/cli.js
-import path2 from "node:path";
+import path4 from "node:path";
 
-// src/story.js
-import { Buffer } from "node:buffer";
-import fs from "node:fs";
-import path from "node:path";
+// src/import.js
+import fs2 from "node:fs";
+import path3 from "node:path";
 
 // src/frontmatter.js
 var FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
@@ -197,6 +196,229 @@ function stripLeadingH1(markdownBody) {
 }
 
 // src/story.js
+import { Buffer } from "node:buffer";
+import fs from "node:fs";
+import path2 from "node:path";
+
+// src/continuity.js
+import path from "node:path";
+var CHEKHOV_CHAPTER_GAP = 3;
+function checkContinuity(project) {
+  const errors = [];
+  const warnings = [];
+  const context = {
+    chapterNumbers: new Map(project.chapters.map((chapter) => [chapter.id, chapter.number])),
+    characters: new Map(project.characters.map((character) => [character.id, character])),
+    locations: new Set(project.locations.map((location) => location.id)),
+    artifacts: new Map(project.artifacts.map((artifact) => [artifact.id, artifact])),
+    factions: new Set(project.factions.map((faction) => faction.id)),
+    latestChapter: project.chapters.reduce((max, chapter) => Math.max(max, chapter.number), 0)
+  };
+  checkCharacterDeaths(project, context, errors);
+  checkChapterCasts(project, warnings);
+  checkSceneCasts(project, warnings);
+  checkChapterSequence(project, warnings);
+  checkPromises(project, context, errors, warnings);
+  checkQuestions(project, context, errors);
+  checkStoryCompletion(project, errors);
+  checkContinuityState(project, context, errors, warnings);
+  return { ok: errors.length === 0, errors, warnings };
+}
+function checkCharacterDeaths(project, context, errors) {
+  for (const character of project.characters) {
+    if (!character.diedIn) {
+      continue;
+    }
+    const label = relative(project, character.file);
+    if (character.status !== "deceased") {
+      errors.push(`${label} has died-in ${character.diedIn} but status ${character.status || "unset"}; set status: deceased`);
+    }
+    const deathNumber = context.chapterNumbers.get(character.diedIn);
+    if (deathNumber === undefined) {
+      errors.push(`${label} died-in references missing chapter ${character.diedIn}`);
+      continue;
+    }
+    for (const chapter of project.chapters) {
+      if (chapter.number > deathNumber && castIncludes(chapter, character.id)) {
+        errors.push(`${relative(project, chapter.file)} lists ${character.id}, who died in ${character.diedIn}; move posthumous appearances to mentions`);
+      }
+    }
+    for (const scene of project.scenes) {
+      const sceneChapterNumber = context.chapterNumbers.get(scene.chapter);
+      if (sceneChapterNumber !== undefined && sceneChapterNumber > deathNumber && castIncludes(scene, character.id)) {
+        errors.push(`${relative(project, scene.file)} lists ${character.id}, who died in ${character.diedIn}; move posthumous appearances to mentions`);
+      }
+    }
+  }
+}
+function checkChapterCasts(project, warnings) {
+  for (const chapter of project.chapters) {
+    if (chapter.pov && !chapter.characters.includes(chapter.pov)) {
+      warnings.push(`${relative(project, chapter.file)} POV character ${chapter.pov} is not listed in characters`);
+    }
+  }
+}
+function checkSceneCasts(project, warnings) {
+  const chapters = new Map(project.chapters.map((chapter) => [chapter.id, chapter]));
+  for (const scene of project.scenes) {
+    const label = relative(project, scene.file);
+    if (scene.pov && !scene.characters.includes(scene.pov)) {
+      warnings.push(`${label} POV character ${scene.pov} is not listed in characters`);
+    }
+    const chapter = chapters.get(scene.chapter);
+    if (!chapter) {
+      continue;
+    }
+    for (const characterId of scene.characters) {
+      if (!chapter.characters.includes(characterId) && !chapter.mentions.includes(characterId)) {
+        warnings.push(`${label} lists ${characterId} but ${relative(project, chapter.file)} does not list them in characters or mentions`);
+      }
+    }
+    if (scene.location && chapter.locations.length > 0 && !chapter.locations.includes(scene.location)) {
+      warnings.push(`${label} is set in ${scene.location} but ${relative(project, chapter.file)} does not list that location`);
+    }
+  }
+}
+function checkChapterSequence(project, warnings) {
+  const numbers = project.chapters.map((chapter) => chapter.number).filter((number) => Number.isInteger(number) && number > 0).sort((left, right) => left - right);
+  for (let index = 1;index < numbers.length; index += 1) {
+    if (numbers[index] > numbers[index - 1] + 1) {
+      warnings.push(`Chapter numbering skips from ${numbers[index - 1]} to ${numbers[index]}`);
+    }
+  }
+}
+function checkPromises(project, context, errors, warnings) {
+  for (const promise of project.promises) {
+    const label = relative(project, promise.file);
+    const plantedNumber = context.chapterNumbers.get(promise.planted);
+    const payoffNumber = context.chapterNumbers.get(promise.payoff);
+    if (plantedNumber !== undefined && payoffNumber !== undefined && payoffNumber < plantedNumber) {
+      errors.push(`${label} pays off in ${promise.payoff} before it is planted in ${promise.planted}`);
+    }
+    if (promise.status === "paid-off" && !promise.payoff) {
+      errors.push(`${label} is paid-off but has no payoff chapter`);
+    }
+    if (promise.status === "planted" && !promise.planted) {
+      errors.push(`${label} is planted but has no planted chapter`);
+    }
+    if (promise.status === "planned" && promise.planted) {
+      warnings.push(`${label} records planted chapter ${promise.planted} but status is still planned`);
+    }
+    if (promise.status === "planted" && plantedNumber !== undefined && context.latestChapter - plantedNumber >= CHEKHOV_CHAPTER_GAP) {
+      warnings.push(`${label} was planted in ${promise.planted}, ${context.latestChapter - plantedNumber} chapters ago, and has no payoff yet`);
+    }
+  }
+}
+function checkQuestions(project, context, errors) {
+  for (const question of project.questions) {
+    const label = relative(project, question.file);
+    const introducedNumber = context.chapterNumbers.get(question.introduced);
+    const resolvedNumber = context.chapterNumbers.get(question.resolved);
+    if (introducedNumber !== undefined && resolvedNumber !== undefined && resolvedNumber < introducedNumber) {
+      errors.push(`${label} resolves in ${question.resolved} before it is introduced in ${question.introduced}`);
+    }
+    if ((question.status === "answered" || question.status === "resolved") && !question.resolved) {
+      errors.push(`${label} is ${question.status} but has no resolved chapter`);
+    }
+    if (question.status === "open" && question.resolved) {
+      errors.push(`${label} records resolved chapter ${question.resolved} but status is still open`);
+    }
+  }
+}
+function checkStoryCompletion(project, errors) {
+  if (project.story.data.status !== "complete") {
+    return;
+  }
+  for (const promise of project.promises) {
+    if (promise.status === "planned" || promise.status === "planted") {
+      errors.push(`story.md is complete but ${relative(project, promise.file)} is still ${promise.status}`);
+    }
+  }
+  for (const question of project.questions) {
+    if (question.status === "open") {
+      errors.push(`story.md is complete but ${relative(project, question.file)} is still open`);
+    }
+  }
+}
+function checkContinuityState(project, context, errors, warnings) {
+  if (!project.continuity) {
+    return;
+  }
+  const label = path.join("continuity", "state.md");
+  const data = project.continuity.data;
+  const currentChapter = data["current-chapter"];
+  if (Number.isInteger(currentChapter)) {
+    if (currentChapter > context.latestChapter) {
+      errors.push(`${label} current-chapter ${currentChapter} is ahead of the latest chapter ${context.latestChapter}`);
+    } else if (currentChapter < context.latestChapter) {
+      warnings.push(`${label} current-chapter ${currentChapter} is behind the latest chapter ${context.latestChapter}; update continuity state after drafting`);
+    }
+  }
+  for (const [index, entry] of stateEntries(data["character-state"]).entries()) {
+    const entryLabel = `${label} character-state[${index}]`;
+    if (!requireMapping(entry, entryLabel, errors)) {
+      continue;
+    }
+    if (!entry.character || !context.characters.has(entry.character)) {
+      errors.push(`${entryLabel} references missing character ${entry.character || "(unset)"}`);
+    }
+    if (entry.location && !context.locations.has(entry.location)) {
+      errors.push(`${entryLabel} references missing location ${entry.location}`);
+    }
+  }
+  for (const [index, entry] of stateEntries(data["knowledge-state"]).entries()) {
+    const entryLabel = `${label} knowledge-state[${index}]`;
+    if (!requireMapping(entry, entryLabel, errors)) {
+      continue;
+    }
+    if (!entry.character || !context.characters.has(entry.character)) {
+      errors.push(`${entryLabel} references missing character ${entry.character || "(unset)"}`);
+    }
+    if (!entry.knows) {
+      errors.push(`${entryLabel} is missing knows`);
+    }
+    if (entry["learned-in"] && !context.chapterNumbers.has(entry["learned-in"])) {
+      errors.push(`${entryLabel} references missing chapter ${entry["learned-in"]}`);
+    }
+  }
+  for (const [index, entry] of stateEntries(data["object-state"]).entries()) {
+    const entryLabel = `${label} object-state[${index}]`;
+    if (!requireMapping(entry, entryLabel, errors)) {
+      continue;
+    }
+    const artifact = context.artifacts.get(entry.artifact);
+    if (!entry.artifact || !artifact) {
+      errors.push(`${entryLabel} references missing artifact ${entry.artifact || "(unset)"}`);
+    }
+    if (entry.owner && !context.characters.has(entry.owner) && !context.factions.has(entry.owner)) {
+      errors.push(`${entryLabel} references missing owner ${entry.owner}`);
+    }
+    if (entry.location && !context.locations.has(entry.location)) {
+      errors.push(`${entryLabel} references missing location ${entry.location}`);
+    }
+    if (entry.status && artifact && artifact.status && entry.status !== artifact.status) {
+      warnings.push(`${entryLabel} status ${entry.status} conflicts with ${relative(project, artifact.file)} status ${artifact.status}`);
+    }
+  }
+}
+function castIncludes(record, characterId) {
+  return record.pov === characterId || record.characters.includes(characterId);
+}
+function stateEntries(value) {
+  return Array.isArray(value) ? value : [];
+}
+function requireMapping(entry, entryLabel, errors) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    errors.push(`${entryLabel} must be a mapping`);
+    return false;
+  }
+  return true;
+}
+function relative(project, file) {
+  return path.relative(project.root, file);
+}
+
+// src/story.js
 var STORY_SCHEMA_VERSION = 2;
 var REQUIRED_PATHS = [
   "story.md",
@@ -220,15 +442,15 @@ var REQUIRED_PATHS = [
   "glossary/terms"
 ];
 var INDEX_SCHEMAS = [
-  [path.join("characters", "_index.md"), "character-registry"],
-  [path.join("worldbuilding", "_index.md"), "world-registry"],
-  [path.join("plot", "_index.md"), "plot-registry"],
-  [path.join("plot", "timeline.md"), "timeline"],
-  [path.join("chapters", "_index.md"), "chapter-registry"],
-  [path.join("scenes", "_index.md"), "scene-registry"],
-  [path.join("continuity", "questions", "_index.md"), "question-registry"],
-  [path.join("continuity", "promises", "_index.md"), "promise-registry"],
-  [path.join("glossary", "_index.md"), "glossary-registry"]
+  [path2.join("characters", "_index.md"), "character-registry"],
+  [path2.join("worldbuilding", "_index.md"), "world-registry"],
+  [path2.join("plot", "_index.md"), "plot-registry"],
+  [path2.join("plot", "timeline.md"), "timeline"],
+  [path2.join("chapters", "_index.md"), "chapter-registry"],
+  [path2.join("scenes", "_index.md"), "scene-registry"],
+  [path2.join("continuity", "questions", "_index.md"), "question-registry"],
+  [path2.join("continuity", "promises", "_index.md"), "promise-registry"],
+  [path2.join("glossary", "_index.md"), "glossary-registry"]
 ];
 var STORY_STATUSES = new Set(["planning", "drafting", "in-progress", "revising", "complete", "abandoned"]);
 var STORY_TENSES = new Set(["past", "present", "future", "mixed"]);
@@ -279,23 +501,23 @@ function createStoryProject(options) {
     throw new Error("A story title is required");
   }
   const storyId = kebabCase(title);
-  const root = path.resolve(options.cwd ?? process.cwd(), options.dir ?? storyId);
+  const root = path2.resolve(options.cwd ?? process.cwd(), options.dir ?? storyId);
   if (fs.existsSync(root) && !options.force) {
     throw new Error(`${root} already exists. Use --force to overwrite starter files.`);
   }
   const themes = normalizeList(options.themes, ["change"]);
-  fs.mkdirSync(path.join(root, "characters"), { recursive: true });
-  fs.mkdirSync(path.join(root, "worldbuilding", "locations"), { recursive: true });
-  fs.mkdirSync(path.join(root, "worldbuilding", "systems"), { recursive: true });
-  fs.mkdirSync(path.join(root, "worldbuilding", "factions"), { recursive: true });
-  fs.mkdirSync(path.join(root, "worldbuilding", "artifacts"), { recursive: true });
-  fs.mkdirSync(path.join(root, "plot", "arcs"), { recursive: true });
-  fs.mkdirSync(path.join(root, "chapters"), { recursive: true });
-  fs.mkdirSync(path.join(root, "scenes"), { recursive: true });
-  fs.mkdirSync(path.join(root, "continuity", "questions"), { recursive: true });
-  fs.mkdirSync(path.join(root, "continuity", "promises"), { recursive: true });
-  fs.mkdirSync(path.join(root, "glossary", "terms"), { recursive: true });
-  writeFile(path.join(root, "story.md"), storyBible({
+  fs.mkdirSync(path2.join(root, "characters"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "worldbuilding", "locations"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "worldbuilding", "systems"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "worldbuilding", "factions"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "worldbuilding", "artifacts"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "plot", "arcs"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "chapters"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "scenes"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "continuity", "questions"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "continuity", "promises"), { recursive: true });
+  fs.mkdirSync(path2.join(root, "glossary", "terms"), { recursive: true });
+  writeFile(path2.join(root, "story.md"), storyBible({
     title,
     storyId,
     genre: options.genre ?? "fiction",
@@ -306,22 +528,22 @@ function createStoryProject(options) {
     tense: options.tense ?? "past",
     synopsis: options.synopsis ?? "Add a 2-3 sentence synopsis here."
   }), { root });
-  writeFile(path.join(root, "characters", "_index.md"), characterIndex(storyId, [], "", ""), { root });
-  writeFile(path.join(root, "worldbuilding", "_index.md"), worldIndex(storyId, [], [], [], [], ""), { root });
-  writeFile(path.join(root, "plot", "_index.md"), plotIndex(storyId, "three-act", [], "", ""), { root });
-  writeFile(path.join(root, "plot", "timeline.md"), timeline(storyId), { root });
-  writeFile(path.join(root, "chapters", "_index.md"), chapterIndex(storyId, []), { root });
-  writeFile(path.join(root, "scenes", "_index.md"), sceneIndex(storyId, []), { root });
-  writeFile(path.join(root, "continuity", "state.md"), continuityState(storyId), { root });
-  writeFile(path.join(root, "continuity", "questions", "_index.md"), questionIndex(storyId, []), { root });
-  writeFile(path.join(root, "continuity", "promises", "_index.md"), promiseIndex(storyId, []), { root });
-  writeFile(path.join(root, "glossary", "_index.md"), glossaryIndex(storyId, []), { root });
+  writeFile(path2.join(root, "characters", "_index.md"), characterIndex(storyId, [], "", ""), { root });
+  writeFile(path2.join(root, "worldbuilding", "_index.md"), worldIndex(storyId, [], [], [], [], ""), { root });
+  writeFile(path2.join(root, "plot", "_index.md"), plotIndex(storyId, "three-act", [], "", ""), { root });
+  writeFile(path2.join(root, "plot", "timeline.md"), timeline(storyId), { root });
+  writeFile(path2.join(root, "chapters", "_index.md"), chapterIndex(storyId, []), { root });
+  writeFile(path2.join(root, "scenes", "_index.md"), sceneIndex(storyId, []), { root });
+  writeFile(path2.join(root, "continuity", "state.md"), continuityState(storyId), { root });
+  writeFile(path2.join(root, "continuity", "questions", "_index.md"), questionIndex(storyId, []), { root });
+  writeFile(path2.join(root, "continuity", "promises", "_index.md"), promiseIndex(storyId, []), { root });
+  writeFile(path2.join(root, "glossary", "_index.md"), glossaryIndex(storyId, []), { root });
   return { root, storyId, files: REQUIRED_PATHS.filter((entry) => entry.endsWith(".md")) };
 }
 function scanProject(root) {
-  const projectRoot = path.resolve(root);
-  const story = readMarkdown(path.join(projectRoot, "story.md"), projectRoot);
-  const storyId = kebabCase(story.data.title ?? path.basename(projectRoot));
+  const projectRoot = path2.resolve(root);
+  const story = readMarkdown(path2.join(projectRoot, "story.md"), projectRoot);
+  const storyId = kebabCase(story.data.title ?? path2.basename(projectRoot));
   return {
     root: projectRoot,
     story,
@@ -332,10 +554,11 @@ function scanProject(root) {
       name: data.name ?? titleCaseSlug(id),
       role: data.role ?? "",
       status: data.status ?? "",
+      diedIn: data["died-in"] ?? "",
       relationships: asArray(data.relationships),
       locations: asArray(data.locations)
     })),
-    locations: readEntityFiles(projectRoot, path.join("worldbuilding", "locations"), (id, file, data) => ({
+    locations: readEntityFiles(projectRoot, path2.join("worldbuilding", "locations"), (id, file, data) => ({
       id,
       file,
       name: data.name ?? titleCaseSlug(id),
@@ -343,13 +566,13 @@ function scanProject(root) {
       region: data.region ?? "",
       notableCharacters: asArray(data["notable-characters"])
     })),
-    systems: readEntityFiles(projectRoot, path.join("worldbuilding", "systems"), (id, file, data) => ({
+    systems: readEntityFiles(projectRoot, path2.join("worldbuilding", "systems"), (id, file, data) => ({
       id,
       file,
       name: data.name ?? titleCaseSlug(id),
       type: data.type ?? ""
     })),
-    factions: readEntityFiles(projectRoot, path.join("worldbuilding", "factions"), (id, file, data) => ({
+    factions: readEntityFiles(projectRoot, path2.join("worldbuilding", "factions"), (id, file, data) => ({
       id,
       file,
       name: data.name ?? titleCaseSlug(id),
@@ -358,7 +581,7 @@ function scanProject(root) {
       members: asArray(data.members),
       locations: asArray(data.locations)
     })),
-    artifacts: readEntityFiles(projectRoot, path.join("worldbuilding", "artifacts"), (id, file, data) => ({
+    artifacts: readEntityFiles(projectRoot, path2.join("worldbuilding", "artifacts"), (id, file, data) => ({
       id,
       file,
       name: data.name ?? titleCaseSlug(id),
@@ -367,7 +590,7 @@ function scanProject(root) {
       owner: data.owner ?? "",
       location: data.location ?? ""
     })),
-    arcs: readEntityFiles(projectRoot, path.join("plot", "arcs"), (id, file, data) => ({
+    arcs: readEntityFiles(projectRoot, path2.join("plot", "arcs"), (id, file, data) => ({
       id,
       file,
       name: data.name ?? titleCaseSlug(id),
@@ -384,6 +607,7 @@ function scanProject(root) {
       pov: data.pov ?? "",
       status: data.status ?? "",
       characters: asArray(data.characters),
+      mentions: asArray(data.mentions),
       locations: asArray(data.locations),
       arcsAdvanced: asArray(data["arcs-advanced"]),
       declaredWordCount: Number(data["word-count"] ?? 0),
@@ -399,10 +623,11 @@ function scanProject(root) {
       location: data.location ?? "",
       status: data.status ?? "",
       characters: asArray(data.characters),
+      mentions: asArray(data.mentions),
       arcsAdvanced: asArray(data["arcs-advanced"]),
       stateChanges: asArray(data["state-changes"])
     })).sort((left, right) => left.chapter.localeCompare(right.chapter) || left.scene - right.scene || left.file.localeCompare(right.file)),
-    questions: readEntityFiles(projectRoot, path.join("continuity", "questions"), (id, file, data) => ({
+    questions: readEntityFiles(projectRoot, path2.join("continuity", "questions"), (id, file, data) => ({
       id,
       file,
       title: data.title ?? titleCaseSlug(id),
@@ -411,7 +636,7 @@ function scanProject(root) {
       resolved: data.resolved ?? "",
       characters: asArray(data.characters)
     })),
-    promises: readEntityFiles(projectRoot, path.join("continuity", "promises"), (id, file, data) => ({
+    promises: readEntityFiles(projectRoot, path2.join("continuity", "promises"), (id, file, data) => ({
       id,
       file,
       title: data.title ?? titleCaseSlug(id),
@@ -421,22 +646,22 @@ function scanProject(root) {
       arcs: asArray(data.arcs),
       characters: asArray(data.characters)
     })),
-    glossaryTerms: readEntityFiles(projectRoot, path.join("glossary", "terms"), (id, file, data) => ({
+    glossaryTerms: readEntityFiles(projectRoot, path2.join("glossary", "terms"), (id, file, data) => ({
       id,
       file,
       term: data.term ?? titleCaseSlug(id),
       category: data.category ?? "",
       aliases: asArray(data.aliases)
     })),
-    continuity: fs.existsSync(path.join(projectRoot, "continuity", "state.md")) ? readMarkdown(path.join(projectRoot, "continuity", "state.md"), projectRoot) : null
+    continuity: fs.existsSync(path2.join(projectRoot, "continuity", "state.md")) ? readMarkdown(path2.join(projectRoot, "continuity", "state.md"), projectRoot) : null
   };
 }
 function validateProject(root) {
-  const projectRoot = path.resolve(root);
+  const projectRoot = path2.resolve(root);
   const errors = [];
   const warnings = [];
   for (const requiredPath of REQUIRED_PATHS) {
-    if (!fs.existsSync(path.join(projectRoot, requiredPath))) {
+    if (!fs.existsSync(path2.join(projectRoot, requiredPath))) {
       errors.push(`Missing required path: ${requiredPath}`);
     }
   }
@@ -459,17 +684,17 @@ function validateProject(root) {
   validatePromises(project, errors);
   validateGlossaryTerms(project, errors);
   const indexChecks = [
-    [path.join("characters", "_index.md"), project.characters.map((item) => `](${item.id}.md)`)],
-    [path.join("worldbuilding", "_index.md"), project.locations.map((item) => `](locations/${item.id}.md)`).concat(project.systems.map((item) => `](systems/${item.id}.md)`)).concat(project.factions.map((item) => `](factions/${item.id}.md)`)).concat(project.artifacts.map((item) => `](artifacts/${item.id}.md)`))],
-    [path.join("plot", "_index.md"), project.arcs.map((item) => `](arcs/${item.id}.md)`)],
-    [path.join("chapters", "_index.md"), project.chapters.map((item) => `](${path.basename(item.file)})`)],
-    [path.join("scenes", "_index.md"), project.scenes.map((item) => `](${item.id}.md)`)],
-    [path.join("continuity", "questions", "_index.md"), project.questions.map((item) => `](${item.id}.md)`)],
-    [path.join("continuity", "promises", "_index.md"), project.promises.map((item) => `](${item.id}.md)`)],
-    [path.join("glossary", "_index.md"), project.glossaryTerms.map((item) => `](terms/${item.id}.md)`)]
+    [path2.join("characters", "_index.md"), project.characters.map((item) => `](${item.id}.md)`)],
+    [path2.join("worldbuilding", "_index.md"), project.locations.map((item) => `](locations/${item.id}.md)`).concat(project.systems.map((item) => `](systems/${item.id}.md)`)).concat(project.factions.map((item) => `](factions/${item.id}.md)`)).concat(project.artifacts.map((item) => `](artifacts/${item.id}.md)`))],
+    [path2.join("plot", "_index.md"), project.arcs.map((item) => `](arcs/${item.id}.md)`)],
+    [path2.join("chapters", "_index.md"), project.chapters.map((item) => `](${path2.basename(item.file)})`)],
+    [path2.join("scenes", "_index.md"), project.scenes.map((item) => `](${item.id}.md)`)],
+    [path2.join("continuity", "questions", "_index.md"), project.questions.map((item) => `](${item.id}.md)`)],
+    [path2.join("continuity", "promises", "_index.md"), project.promises.map((item) => `](${item.id}.md)`)],
+    [path2.join("glossary", "_index.md"), project.glossaryTerms.map((item) => `](terms/${item.id}.md)`)]
   ];
   for (const [indexPath, links] of indexChecks) {
-    const markdown = safeRead(path.join(projectRoot, indexPath), projectRoot);
+    const markdown = safeRead(path2.join(projectRoot, indexPath), projectRoot);
     for (const link of links) {
       if (!markdown.includes(link)) {
         warnings.push(`${indexPath} is missing registry link ${link}`);
@@ -478,10 +703,10 @@ function validateProject(root) {
   }
   for (const chapter of project.chapters) {
     if (chapter.declaredWordCount !== chapter.wordCount) {
-      warnings.push(`${path.relative(projectRoot, chapter.file)} declares ${chapter.declaredWordCount} words but contains ${chapter.wordCount}`);
+      warnings.push(`${path2.relative(projectRoot, chapter.file)} declares ${chapter.declaredWordCount} words but contains ${chapter.wordCount}`);
     }
     if (!project.scenes.some((scene) => scene.chapter === chapter.id)) {
-      warnings.push(`${path.relative(projectRoot, chapter.file)} has no machine-readable scene records`);
+      warnings.push(`${path2.relative(projectRoot, chapter.file)} has no machine-readable scene records`);
     }
   }
   return { ok: errors.length === 0, errors, warnings };
@@ -499,137 +724,141 @@ function validateLinks(root) {
     for (const relationship of character.relationships) {
       const target = relationship.character;
       if (!characters.has(target)) {
-        errors.push(`${relative(project, character.file)} references missing character ${target}`);
+        errors.push(`${relative2(project, character.file)} references missing character ${target}`);
       } else if (!characters.get(target).relationships.some((entry) => entry.character === character.id)) {
-        errors.push(`${relative(project, character.file)} relationship to ${target} is missing backlink`);
+        errors.push(`${relative2(project, character.file)} relationship to ${target} is missing backlink`);
       } else {
         const backlink = characters.get(target).relationships.find((entry) => entry.character === character.id);
         const expectedType = inverseRelationshipType(relationship.type);
         if (expectedType && backlink.type !== expectedType) {
-          errors.push(`${relative(project, character.file)} relationship ${relationship.type} to ${target} expects backlink type ${expectedType}, got ${backlink.type}`);
+          errors.push(`${relative2(project, character.file)} relationship ${relationship.type} to ${target} expects backlink type ${expectedType}, got ${backlink.type}`);
         }
       }
     }
     for (const locationId of character.locations) {
       if (!locations.has(locationId)) {
-        errors.push(`${relative(project, character.file)} references missing location ${locationId}`);
+        errors.push(`${relative2(project, character.file)} references missing location ${locationId}`);
       } else if (!locations.get(locationId).notableCharacters.includes(character.id)) {
-        errors.push(`${relative(project, character.file)} location ${locationId} is missing notable-character backlink`);
+        errors.push(`${relative2(project, character.file)} location ${locationId} is missing notable-character backlink`);
       }
     }
   }
   for (const location of project.locations) {
     for (const characterId of location.notableCharacters) {
       if (!characters.has(characterId)) {
-        errors.push(`${relative(project, location.file)} references missing character ${characterId}`);
+        errors.push(`${relative2(project, location.file)} references missing character ${characterId}`);
       } else if (!characters.get(characterId).locations.includes(location.id)) {
-        errors.push(`${relative(project, location.file)} notable character ${characterId} is missing location backlink`);
+        errors.push(`${relative2(project, location.file)} notable character ${characterId} is missing location backlink`);
       }
     }
   }
   for (const arc of project.arcs) {
     for (const characterId of arc.characters) {
       if (!characters.has(characterId)) {
-        errors.push(`${relative(project, arc.file)} references missing character ${characterId}`);
+        errors.push(`${relative2(project, arc.file)} references missing character ${characterId}`);
       }
     }
   }
   for (const chapter of project.chapters) {
     if (chapter.pov && !characters.has(chapter.pov)) {
-      errors.push(`${relative(project, chapter.file)} references missing POV character ${chapter.pov}`);
+      errors.push(`${relative2(project, chapter.file)} references missing POV character ${chapter.pov}`);
     }
-    for (const characterId of chapter.characters) {
+    for (const characterId of chapter.characters.concat(chapter.mentions)) {
       if (!characters.has(characterId)) {
-        errors.push(`${relative(project, chapter.file)} references missing character ${characterId}`);
+        errors.push(`${relative2(project, chapter.file)} references missing character ${characterId}`);
       }
     }
     for (const locationId of chapter.locations) {
       if (!locations.has(locationId)) {
-        errors.push(`${relative(project, chapter.file)} references missing location ${locationId}`);
+        errors.push(`${relative2(project, chapter.file)} references missing location ${locationId}`);
       }
     }
     for (const arcId of chapter.arcsAdvanced) {
       if (!arcs.has(arcId)) {
-        errors.push(`${relative(project, chapter.file)} references missing arc ${arcId}`);
+        errors.push(`${relative2(project, chapter.file)} references missing arc ${arcId}`);
       }
     }
   }
   for (const faction of project.factions) {
     for (const characterId of faction.members) {
       if (!characters.has(characterId)) {
-        errors.push(`${relative(project, faction.file)} references missing member ${characterId}`);
+        errors.push(`${relative2(project, faction.file)} references missing member ${characterId}`);
       }
     }
     for (const locationId of faction.locations) {
       if (!locations.has(locationId)) {
-        errors.push(`${relative(project, faction.file)} references missing location ${locationId}`);
+        errors.push(`${relative2(project, faction.file)} references missing location ${locationId}`);
       }
     }
   }
   for (const artifact of project.artifacts) {
     if (artifact.owner && !characters.has(artifact.owner) && !factions.has(artifact.owner)) {
-      errors.push(`${relative(project, artifact.file)} references missing owner ${artifact.owner}`);
+      errors.push(`${relative2(project, artifact.file)} references missing owner ${artifact.owner}`);
     }
     if (artifact.location && !locations.has(artifact.location)) {
-      errors.push(`${relative(project, artifact.file)} references missing location ${artifact.location}`);
+      errors.push(`${relative2(project, artifact.file)} references missing location ${artifact.location}`);
     }
   }
   for (const scene of project.scenes) {
     if (scene.chapter && !chapters.has(scene.chapter)) {
-      errors.push(`${relative(project, scene.file)} references missing chapter ${scene.chapter}`);
+      errors.push(`${relative2(project, scene.file)} references missing chapter ${scene.chapter}`);
     }
     if (scene.pov && !characters.has(scene.pov)) {
-      errors.push(`${relative(project, scene.file)} references missing POV character ${scene.pov}`);
+      errors.push(`${relative2(project, scene.file)} references missing POV character ${scene.pov}`);
     }
     if (scene.location && !locations.has(scene.location)) {
-      errors.push(`${relative(project, scene.file)} references missing location ${scene.location}`);
+      errors.push(`${relative2(project, scene.file)} references missing location ${scene.location}`);
     }
-    for (const characterId of scene.characters) {
+    for (const characterId of scene.characters.concat(scene.mentions)) {
       if (!characters.has(characterId)) {
-        errors.push(`${relative(project, scene.file)} references missing character ${characterId}`);
+        errors.push(`${relative2(project, scene.file)} references missing character ${characterId}`);
       }
     }
     for (const arcId of scene.arcsAdvanced) {
       if (!arcs.has(arcId)) {
-        errors.push(`${relative(project, scene.file)} references missing arc ${arcId}`);
+        errors.push(`${relative2(project, scene.file)} references missing arc ${arcId}`);
       }
     }
   }
   for (const question of project.questions) {
     for (const chapterId of [question.introduced, question.resolved].filter(Boolean)) {
       if (!chapters.has(chapterId)) {
-        errors.push(`${relative(project, question.file)} references missing chapter ${chapterId}`);
+        errors.push(`${relative2(project, question.file)} references missing chapter ${chapterId}`);
       }
     }
     for (const characterId of question.characters) {
       if (!characters.has(characterId)) {
-        errors.push(`${relative(project, question.file)} references missing character ${characterId}`);
+        errors.push(`${relative2(project, question.file)} references missing character ${characterId}`);
       }
     }
   }
   for (const promise of project.promises) {
     for (const chapterId of [promise.planted, promise.payoff].filter(Boolean)) {
       if (!chapters.has(chapterId)) {
-        errors.push(`${relative(project, promise.file)} references missing chapter ${chapterId}`);
+        errors.push(`${relative2(project, promise.file)} references missing chapter ${chapterId}`);
       }
     }
     for (const arcId of promise.arcs) {
       if (!arcs.has(arcId)) {
-        errors.push(`${relative(project, promise.file)} references missing arc ${arcId}`);
+        errors.push(`${relative2(project, promise.file)} references missing arc ${arcId}`);
       }
     }
     for (const characterId of promise.characters) {
       if (!characters.has(characterId)) {
-        errors.push(`${relative(project, promise.file)} references missing character ${characterId}`);
+        errors.push(`${relative2(project, promise.file)} references missing character ${characterId}`);
       }
     }
   }
   return { ok: errors.length === 0, errors, warnings };
 }
+function checkProjectContinuity(root) {
+  return checkContinuity(scanProject(root));
+}
 function projectReport(root) {
   const project = scanProject(root);
   const validation = validateProject(project.root);
   const links = validateLinks(project.root);
+  const continuity = checkContinuity(project);
   const totalWords = project.chapters.reduce((sum, chapter) => sum + chapter.wordCount, 0);
   return {
     root: project.root,
@@ -670,7 +899,8 @@ function projectReport(root) {
     })),
     validation,
     links,
-    actions: buildProjectActions(project, validation, links)
+    continuity,
+    actions: buildProjectActions(project, validation, links, continuity)
   };
 }
 function formatProjectReport(report, options = {}) {
@@ -714,7 +944,7 @@ function formatProjectReport(report, options = {}) {
       lines.push(`- ${arc.name} (${arc.type}, ${arc.status}, ${arc.characters} characters)`);
     }
   }
-  lines.push("", "Checks:", `- Validate: ${formatCheck(report.validation)}`, `- Links: ${formatCheck(report.links)}`);
+  lines.push("", "Checks:", `- Validate: ${formatCheck(report.validation)}`, `- Links: ${formatCheck(report.links)}`, `- Continuity: ${formatCheck(report.continuity)}`);
   if (options.actionable) {
     lines.push("", "Next Actions:");
     appendActionLines(lines, report.actions);
@@ -727,20 +957,22 @@ function projectActions(root) {
   const project = scanProject(root);
   const validation = validateProject(project.root);
   const links = validateLinks(project.root);
+  const continuity = checkContinuity(project);
   return {
     root: project.root,
     title: project.story.data.title,
     storyId: project.storyId,
-    actions: buildProjectActions(project, validation, links),
+    actions: buildProjectActions(project, validation, links, continuity),
     validation,
-    links
+    links,
+    continuity
   };
 }
 function formatActionReport(report) {
   const lines = [
     `# Next Writing Actions: ${report.title}`,
     "",
-    `Checks: validate ${formatCheck(report.validation)}, links ${formatCheck(report.links)}`,
+    `Checks: validate ${formatCheck(report.validation)}, links ${formatCheck(report.links)}, continuity ${formatCheck(report.continuity)}`,
     "",
     "Actions:"
   ];
@@ -758,6 +990,7 @@ function formatDoctorReport(report) {
     "Checks:",
     `- Validate: ${formatCheck(report.validation)}`,
     `- Links: ${formatCheck(report.links)}`,
+    `- Continuity: ${formatCheck(report.continuity)}`,
     "",
     "Actions:"
   ];
@@ -769,14 +1002,14 @@ function formatDoctorReport(report) {
 function reindexProject(root) {
   const project = scanProject(root);
   const changed = [];
-  const charactersIndexPath = path.join(project.root, "characters", "_index.md");
-  const worldIndexPath = path.join(project.root, "worldbuilding", "_index.md");
-  const plotIndexPath = path.join(project.root, "plot", "_index.md");
-  const chaptersIndexPath = path.join(project.root, "chapters", "_index.md");
-  const scenesIndexPath = path.join(project.root, "scenes", "_index.md");
-  const questionsIndexPath = path.join(project.root, "continuity", "questions", "_index.md");
-  const promisesIndexPath = path.join(project.root, "continuity", "promises", "_index.md");
-  const glossaryIndexPath = path.join(project.root, "glossary", "_index.md");
+  const charactersIndexPath = path2.join(project.root, "characters", "_index.md");
+  const worldIndexPath = path2.join(project.root, "worldbuilding", "_index.md");
+  const plotIndexPath = path2.join(project.root, "plot", "_index.md");
+  const chaptersIndexPath = path2.join(project.root, "chapters", "_index.md");
+  const scenesIndexPath = path2.join(project.root, "scenes", "_index.md");
+  const questionsIndexPath = path2.join(project.root, "continuity", "questions", "_index.md");
+  const promisesIndexPath = path2.join(project.root, "continuity", "promises", "_index.md");
+  const glossaryIndexPath = path2.join(project.root, "glossary", "_index.md");
   const existingCharacters = safeRead(charactersIndexPath, project.root);
   const existingWorld = safeRead(worldIndexPath, project.root);
   const existingPlot = safeRead(plotIndexPath, project.root);
@@ -798,7 +1031,7 @@ function computeWordCounts(root, options = {}) {
     chapters.push({
       number: chapter.number,
       title: chapter.title,
-      file: path.relative(project.root, chapter.file),
+      file: path2.relative(project.root, chapter.file),
       wordCount: chapter.wordCount
     });
     if (options.write) {
@@ -838,7 +1071,7 @@ function buildBook(root, options = {}) {
   const format = normalizeBuildFormat(options.format ?? "markdown");
   const project = scanProject(root);
   const extension = format === "markdown" ? "md" : format;
-  const output = resolveOutputPath(project, options.out, path.join("dist", `${project.storyId}.${extension}`));
+  const output = resolveOutputPath(project, options.out, path2.join("dist", `${project.storyId}.${extension}`));
   if (format === "markdown") {
     const result = exportManuscript(project.root, {
       out: output.outFile,
@@ -856,26 +1089,26 @@ function buildBook(root, options = {}) {
   return { outFile: output.outFile, chapters: manuscript.chapters.length, format };
 }
 function migrateProject(root) {
-  const projectRoot = path.resolve(root);
-  const storyPath = path.join(projectRoot, "story.md");
+  const projectRoot = path2.resolve(root);
+  const storyPath = path2.join(projectRoot, "story.md");
   const story = readMarkdown(storyPath, projectRoot);
-  const storyId = kebabCase(story.data.title ?? path.basename(projectRoot));
+  const storyId = kebabCase(story.data.title ?? path2.basename(projectRoot));
   const changed = [];
   for (const directory of [
-    path.join("worldbuilding", "factions"),
-    path.join("worldbuilding", "artifacts"),
+    path2.join("worldbuilding", "factions"),
+    path2.join("worldbuilding", "artifacts"),
     "scenes",
-    path.join("continuity", "questions"),
-    path.join("continuity", "promises"),
-    path.join("glossary", "terms")
+    path2.join("continuity", "questions"),
+    path2.join("continuity", "promises"),
+    path2.join("glossary", "terms")
   ]) {
-    ensureDirectory(path.join(projectRoot, directory), changed, projectRoot);
+    ensureDirectory(path2.join(projectRoot, directory), changed, projectRoot);
   }
-  ensureFile(path.join(projectRoot, "scenes", "_index.md"), sceneIndex(storyId, []), changed, projectRoot);
-  ensureFile(path.join(projectRoot, "continuity", "state.md"), continuityState(storyId), changed, projectRoot);
-  ensureFile(path.join(projectRoot, "continuity", "questions", "_index.md"), questionIndex(storyId, []), changed, projectRoot);
-  ensureFile(path.join(projectRoot, "continuity", "promises", "_index.md"), promiseIndex(storyId, []), changed, projectRoot);
-  ensureFile(path.join(projectRoot, "glossary", "_index.md"), glossaryIndex(storyId, []), changed, projectRoot);
+  ensureFile(path2.join(projectRoot, "scenes", "_index.md"), sceneIndex(storyId, []), changed, projectRoot);
+  ensureFile(path2.join(projectRoot, "continuity", "state.md"), continuityState(storyId), changed, projectRoot);
+  ensureFile(path2.join(projectRoot, "continuity", "questions", "_index.md"), questionIndex(storyId, []), changed, projectRoot);
+  ensureFile(path2.join(projectRoot, "continuity", "promises", "_index.md"), promiseIndex(storyId, []), changed, projectRoot);
+  ensureFile(path2.join(projectRoot, "glossary", "_index.md"), glossaryIndex(storyId, []), changed, projectRoot);
   if (story.data["schema-version"] !== STORY_SCHEMA_VERSION) {
     writeFile(storyPath, replaceFrontmatter(story.rawMarkdown, {
       ...story.data,
@@ -895,7 +1128,7 @@ function createEntity(root, options) {
   }
   const entity = buildEntity(project, kind, name, options);
   if (fs.existsSync(entity.file)) {
-    throw new Error(`${relative(project, entity.file)} already exists`);
+    throw new Error(`${relative2(project, entity.file)} already exists`);
   }
   writeFile(entity.file, entity.markdown, { root: project.root });
   applyEntityBacklinks(project.root, kind, entity.id, readMarkdown(entity.file, project.root).data);
@@ -911,7 +1144,7 @@ function renameEntity(root, options) {
     throw new Error("rename requires an entity id and a new name");
   }
   const config = entityConfig(kind);
-  const oldFile = path.join(project.root, config.dir, `${oldId}.md`);
+  const oldFile = path2.join(project.root, config.dir, `${oldId}.md`);
   requireKebabId(oldId, `${kind} id`);
   assertSafeProjectPath(oldFile, project.root);
   if (!fs.existsSync(oldFile)) {
@@ -919,7 +1152,7 @@ function renameEntity(root, options) {
   }
   const markdown = readMarkdown(oldFile, project.root);
   const newId = kind === "chapter" ? oldId : kebabCase(name);
-  const newFile = path.join(project.root, config.dir, `${newId}.md`);
+  const newFile = path2.join(project.root, config.dir, `${newId}.md`);
   assertSafeProjectPath(newFile, project.root);
   if (newFile !== oldFile && fs.existsSync(newFile)) {
     throw new Error(`${kind} ${newId} already exists`);
@@ -941,7 +1174,7 @@ function removeEntity(root, options) {
     throw new Error("remove requires an entity id");
   }
   const config = entityConfig(kind);
-  const file = path.join(project.root, config.dir, `${id}.md`);
+  const file = path2.join(project.root, config.dir, `${id}.md`);
   requireKebabId(id, `${kind} id`);
   assertSafeProjectPath(file, project.root);
   if (!fs.existsSync(file)) {
@@ -1060,7 +1293,7 @@ ${themeTracking || `| Theme | Arcs | Chapters |
 `;
 }
 function chapterIndex(storyId, chapters) {
-  const rows = chapters.length === 0 ? ["| *No chapters yet* | | | | | |"] : chapters.map((chapter) => `| ${chapter.number} | ${chapter.title} | ${chapter.pov} | ${chapter.status} | ${chapter.wordCount} | [${chapter.id}](${path.basename(chapter.file)}) |`);
+  const rows = chapters.length === 0 ? ["| *No chapters yet* | | | | | |"] : chapters.map((chapter) => `| ${chapter.number} | ${chapter.title} | ${chapter.pov} | ${chapter.status} | ${chapter.wordCount} | [${chapter.id}](${path2.basename(chapter.file)}) |`);
   const total = chapters.reduce((sum, chapter) => sum + chapter.wordCount, 0);
   return `${stringifyFrontmatter({ type: "chapter-registry", story: storyId })}# Chapters
 
@@ -1163,13 +1396,19 @@ ${rows.join(`
 `)}
 `;
 }
-function buildProjectActions(project, validation, links) {
+function buildProjectActions(project, validation, links, continuity) {
   const actions = [];
   if (validation.errors.length > 0) {
     actions.push(action("P0", "Fix validation errors", `Run story validate . and repair ${validation.errors.length} schema or registry errors.`));
   }
   if (links.errors.length > 0) {
     actions.push(action("P0", "Fix broken references", `Run story links . and repair ${links.errors.length} missing references or backlinks.`));
+  }
+  if (continuity.errors.length > 0) {
+    actions.push(action("P0", "Fix continuity contradictions", `Run story continuity . and repair ${continuity.errors.length} deterministic continuity errors.`));
+  }
+  if (continuity.warnings.length > 0) {
+    actions.push(action("P1", "Review continuity warnings", `Run story continuity . and review ${continuity.warnings.length} continuity warnings.`));
   }
   const staleChapters = [];
   const chaptersWithoutScenes = [];
@@ -1224,7 +1463,7 @@ function buildProjectActions(project, validation, links) {
   if (project.characters.length === 0) {
     actions.push(action("P2", "Create first character", 'Use story add character "Name" --role protagonist before drafting prose.'));
   }
-  if (actions.length === 1 && validation.ok && links.ok && staleChapters.length === 0 && chaptersWithoutScenes.length === 0) {
+  if (actions.length === 1 && validation.ok && links.ok && continuity.ok && continuity.warnings.length === 0 && staleChapters.length === 0 && chaptersWithoutScenes.length === 0) {
     actions.unshift(action("P3", "Project is mechanically healthy", "No deterministic maintenance issues are blocking the next writing pass."));
   }
   return actions;
@@ -1280,21 +1519,21 @@ function buildEntity(project, kind, name, options) {
 }
 function entityResult(project, kind, id, markdown) {
   const config = entityConfig(kind);
-  return { id, markdown, file: path.join(project.root, config.dir, `${id}.md`) };
+  return { id, markdown, file: path2.join(project.root, config.dir, `${id}.md`) };
 }
 function entityConfig(kind) {
   const configs = {
     character: { dir: "characters", titleField: "name" },
-    location: { dir: path.join("worldbuilding", "locations"), titleField: "name" },
-    system: { dir: path.join("worldbuilding", "systems"), titleField: "name" },
-    faction: { dir: path.join("worldbuilding", "factions"), titleField: "name" },
-    artifact: { dir: path.join("worldbuilding", "artifacts"), titleField: "name" },
-    arc: { dir: path.join("plot", "arcs"), titleField: "name" },
+    location: { dir: path2.join("worldbuilding", "locations"), titleField: "name" },
+    system: { dir: path2.join("worldbuilding", "systems"), titleField: "name" },
+    faction: { dir: path2.join("worldbuilding", "factions"), titleField: "name" },
+    artifact: { dir: path2.join("worldbuilding", "artifacts"), titleField: "name" },
+    arc: { dir: path2.join("plot", "arcs"), titleField: "name" },
     chapter: { dir: "chapters", titleField: "title" },
     scene: { dir: "scenes", titleField: "title" },
-    question: { dir: path.join("continuity", "questions"), titleField: "title" },
-    promise: { dir: path.join("continuity", "promises"), titleField: "title" },
-    term: { dir: path.join("glossary", "terms"), titleField: "term" }
+    question: { dir: path2.join("continuity", "questions"), titleField: "title" },
+    promise: { dir: path2.join("continuity", "promises"), titleField: "title" },
+    term: { dir: path2.join("glossary", "terms"), titleField: "term" }
   };
   const config = configs[kind];
   if (!config) {
@@ -1673,20 +1912,20 @@ function applyEntityBacklinks(root, kind, id, data) {
   if (kind === "location") {
     for (const characterId of asArray(data["notable-characters"])) {
       if (isKebabId(characterId)) {
-        addFrontmatterListValue(root, path.join("characters", `${characterId}.md`), "locations", id);
+        addFrontmatterListValue(root, path2.join("characters", `${characterId}.md`), "locations", id);
       }
     }
   }
   if (kind === "character") {
     for (const locationId of asArray(data.locations)) {
       if (isKebabId(locationId)) {
-        addFrontmatterListValue(root, path.join("worldbuilding", "locations", `${locationId}.md`), "notable-characters", id);
+        addFrontmatterListValue(root, path2.join("worldbuilding", "locations", `${locationId}.md`), "notable-characters", id);
       }
     }
   }
 }
 function addFrontmatterListValue(root, relativePath, field, value) {
-  const filePath = path.join(root, relativePath);
+  const filePath = path2.join(root, relativePath);
   if (!fs.existsSync(filePath) || !value) {
     return;
   }
@@ -1721,7 +1960,7 @@ function removeReferenceFromData(data, id) {
 function markdownFiles(root) {
   const files = [];
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    const fullPath = path.join(root, entry.name);
+    const fullPath = path2.join(root, entry.name);
     if (entry.isDirectory() && entry.name !== "dist" && !entry.name.startsWith(".")) {
       files.push(...markdownFiles(fullPath));
     } else if (entry.isFile() && entry.name.endsWith(".md")) {
@@ -1891,15 +2130,15 @@ function xmlEscape(value) {
   return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 function readEntityFiles(root, relativeDir, mapEntity) {
-  const directory = path.join(root, relativeDir);
+  const directory = path2.join(root, relativeDir);
   if (!fs.existsSync(directory)) {
     return [];
   }
   assertSafeProjectDirectory(directory, root);
   return fs.readdirSync(directory, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "_index.md").map((entry) => entry.name).sort().map((file) => {
-    const fullPath = path.join(directory, file);
+    const fullPath = path2.join(directory, file);
     const markdown = readMarkdown(fullPath, root);
-    return mapEntity(path.basename(file, ".md"), fullPath, markdown.data, markdown);
+    return mapEntity(path2.basename(file, ".md"), fullPath, markdown.data, markdown);
   });
 }
 function readMarkdown(filePath, root) {
@@ -1931,8 +2170,8 @@ function safeRead(filePath, root) {
 }
 function resolveOutputPath(project, out, defaultRelativePath, enforceRoot) {
   const rawOut = out ?? defaultRelativePath;
-  const outFile = path.resolve(project.root, rawOut);
-  const shouldEnforceRoot = enforceRoot ?? !path.isAbsolute(String(rawOut));
+  const outFile = path2.resolve(project.root, rawOut);
+  const shouldEnforceRoot = enforceRoot ?? !path2.isAbsolute(String(rawOut));
   return {
     outFile,
     enforceRoot: shouldEnforceRoot,
@@ -1940,11 +2179,11 @@ function resolveOutputPath(project, out, defaultRelativePath, enforceRoot) {
   };
 }
 function prepareWriteTarget(filePath, root) {
-  const target = path.resolve(filePath);
+  const target = path2.resolve(filePath);
   if (root) {
     assertLexicallyInsideRoot(target, root);
   }
-  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.mkdirSync(path2.dirname(target), { recursive: true });
   if (root) {
     assertSafeProjectParent(target, root);
   }
@@ -1952,13 +2191,13 @@ function prepareWriteTarget(filePath, root) {
   return target;
 }
 function assertSafeProjectPath(filePath, root) {
-  const target = path.resolve(filePath);
+  const target = path2.resolve(filePath);
   assertLexicallyInsideRoot(target, root);
   assertSafeProjectParent(target, root);
   rejectSymlinkTarget(target);
 }
 function assertSafeProjectDirectory(directory, root) {
-  const target = path.resolve(directory);
+  const target = path2.resolve(directory);
   assertLexicallyInsideRoot(target, root);
   const stats = lstatIfExists(target);
   if (stats) {
@@ -1969,22 +2208,22 @@ function assertSafeProjectDirectory(directory, root) {
       throw new Error(`Project path is not a directory: ${target}`);
     }
   }
-  const rootReal = fs.realpathSync(path.resolve(root));
+  const rootReal = fs.realpathSync(path2.resolve(root));
   const directoryReal = fs.realpathSync(target);
   if (!isPathInside(rootReal, directoryReal)) {
     throw new Error(`Refusing to use project directory outside root: ${target}`);
   }
 }
 function assertSafeProjectParent(filePath, root) {
-  const rootReal = fs.realpathSync(path.resolve(root));
-  const parentReal = fs.realpathSync(path.dirname(path.resolve(filePath)));
+  const rootReal = fs.realpathSync(path2.resolve(root));
+  const parentReal = fs.realpathSync(path2.dirname(path2.resolve(filePath)));
   if (!isPathInside(rootReal, parentReal)) {
     throw new Error(`Refusing to access project path outside root: ${filePath}`);
   }
 }
 function assertLexicallyInsideRoot(filePath, root) {
-  const rootPath = path.resolve(root);
-  const target = path.resolve(filePath);
+  const rootPath = path2.resolve(root);
+  const target = path2.resolve(filePath);
   if (!isPathInside(rootPath, target)) {
     throw new Error(`Refusing to access path outside project root: ${target}`);
   }
@@ -1998,8 +2237,8 @@ function lstatIfExists(filePath) {
   return fs.lstatSync(filePath, { throwIfNoEntry: false }) ?? null;
 }
 function isPathInside(root, target) {
-  const relativePath = path.relative(root, target);
-  return relativePath === "" || !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+  const relativePath = path2.relative(root, target);
+  return relativePath === "" || !relativePath.startsWith("..") && !path2.isAbsolute(relativePath);
 }
 function asArray(value) {
   return Array.isArray(value) ? value : [];
@@ -2045,7 +2284,7 @@ function validateStoryFrontmatter(project, errors) {
 function validateIndexFrontmatter(project, errors) {
   for (const [relativePath, expectedType] of INDEX_SCHEMAS) {
     const label = relativePath;
-    const data = readMarkdown(path.join(project.root, relativePath), project.root).data;
+    const data = readMarkdown(path2.join(project.root, relativePath), project.root).data;
     requireFields(data, ["type", "story"], label, errors);
     requireScalar(data, "type", label, errors);
     requireScalar(data, "story", label, errors);
@@ -2055,7 +2294,7 @@ function validateIndexFrontmatter(project, errors) {
     if (data.story !== undefined && data.story !== project.storyId) {
       errors.push(`${label} story must be ${project.storyId}`);
     }
-    if (relativePath === path.join("plot", "_index.md")) {
+    if (relativePath === path2.join("plot", "_index.md")) {
       requireFields(data, ["structure"], label, errors);
       requireScalar(data, "structure", label, errors);
     }
@@ -2063,7 +2302,7 @@ function validateIndexFrontmatter(project, errors) {
 }
 function validateCharacters(project, errors) {
   for (const character of project.characters) {
-    const label = relative(project, character.file);
+    const label = relative2(project, character.file);
     const data = readMarkdown(character.file, project.root).data;
     validateEntityId(character.id, label, errors);
     requireFields(data, ["name", "role", "status"], label, errors);
@@ -2072,6 +2311,9 @@ function validateCharacters(project, errors) {
     requireScalar(data, "status", label, errors);
     validateEnum(data, "role", CHARACTER_ROLES, label, errors);
     validateEnum(data, "status", CHARACTER_STATUSES, label, errors);
+    if (data["died-in"] !== undefined) {
+      requireScalar(data, "died-in", label, errors);
+    }
     validateStringArray(data, "aliases", label, errors);
     validateStringArray(data, "locations", label, errors);
     validateStringArray(data, "tags", label, errors);
@@ -2080,7 +2322,7 @@ function validateCharacters(project, errors) {
 }
 function validateLocations(project, errors) {
   for (const location of project.locations) {
-    const label = relative(project, location.file);
+    const label = relative2(project, location.file);
     const data = readMarkdown(location.file, project.root).data;
     validateEntityId(location.id, label, errors);
     requireFields(data, ["name", "type"], label, errors);
@@ -2092,7 +2334,7 @@ function validateLocations(project, errors) {
 }
 function validateSystems(project, errors) {
   for (const system of project.systems) {
-    const label = relative(project, system.file);
+    const label = relative2(project, system.file);
     const data = readMarkdown(system.file, project.root).data;
     validateEntityId(system.id, label, errors);
     requireFields(data, ["name", "type"], label, errors);
@@ -2105,7 +2347,7 @@ function validateSystems(project, errors) {
 }
 function validateFactions(project, errors) {
   for (const faction of project.factions) {
-    const label = relative(project, faction.file);
+    const label = relative2(project, faction.file);
     const data = readMarkdown(faction.file, project.root).data;
     validateEntityId(faction.id, label, errors);
     requireFields(data, ["name", "type", "status"], label, errors);
@@ -2121,7 +2363,7 @@ function validateFactions(project, errors) {
 }
 function validateArtifacts(project, errors) {
   for (const artifact of project.artifacts) {
-    const label = relative(project, artifact.file);
+    const label = relative2(project, artifact.file);
     const data = readMarkdown(artifact.file, project.root).data;
     validateEntityId(artifact.id, label, errors);
     requireFields(data, ["name", "type", "status"], label, errors);
@@ -2137,7 +2379,7 @@ function validateArtifacts(project, errors) {
 }
 function validateArcs(project, errors) {
   for (const arc of project.arcs) {
-    const label = relative(project, arc.file);
+    const label = relative2(project, arc.file);
     const data = readMarkdown(arc.file, project.root).data;
     validateEntityId(arc.id, label, errors);
     requireFields(data, ["name", "type", "status"], label, errors);
@@ -2154,7 +2396,7 @@ function validateArcs(project, errors) {
 function validateChapters(project, errors) {
   const seenNumbers = new Map;
   for (const chapter of project.chapters) {
-    const label = relative(project, chapter.file);
+    const label = relative2(project, chapter.file);
     const data = readMarkdown(chapter.file, project.root).data;
     const filenameNumber = chapterNumberFromFile(chapter.file);
     validateEntityId(chapter.id, label, errors);
@@ -2165,6 +2407,7 @@ function validateChapters(project, errors) {
     validateEnum(data, "status", CHAPTER_STATUSES, label, errors);
     validateStringArray(data, "locations", label, errors);
     validateStringArray(data, "characters", label, errors);
+    validateStringArray(data, "mentions", label, errors);
     validateStringArray(data, "arcs-advanced", label, errors);
     if (data.pov !== undefined) {
       requireScalar(data, "pov", label, errors);
@@ -2192,7 +2435,7 @@ function validateChapters(project, errors) {
 }
 function validateScenes(project, errors) {
   for (const scene of project.scenes) {
-    const label = relative(project, scene.file);
+    const label = relative2(project, scene.file);
     const data = readMarkdown(scene.file, project.root).data;
     validateEntityId(scene.id, label, errors);
     requireFields(data, ["title", "chapter", "scene", "status"], label, errors);
@@ -2202,6 +2445,7 @@ function validateScenes(project, errors) {
     requireInteger(data, "scene", label, errors);
     validateEnum(data, "status", SCENE_STATUSES, label, errors);
     validateStringArray(data, "characters", label, errors);
+    validateStringArray(data, "mentions", label, errors);
     validateStringArray(data, "arcs-advanced", label, errors);
     validateObjectArray(data, "state-changes", label, errors);
     if (data.pov !== undefined) {
@@ -2216,7 +2460,7 @@ function validateScenes(project, errors) {
   }
 }
 function validateContinuityState(project, errors) {
-  const label = path.join("continuity", "state.md");
+  const label = path2.join("continuity", "state.md");
   const data = project.continuity.data;
   requireFields(data, ["type", "story", "current-chapter"], label, errors);
   requireScalar(data, "type", label, errors);
@@ -2234,7 +2478,7 @@ function validateContinuityState(project, errors) {
 }
 function validateQuestions(project, errors) {
   for (const question of project.questions) {
-    const label = relative(project, question.file);
+    const label = relative2(project, question.file);
     const data = readMarkdown(question.file, project.root).data;
     validateEntityId(question.id, label, errors);
     requireFields(data, ["title", "status"], label, errors);
@@ -2248,7 +2492,7 @@ function validateQuestions(project, errors) {
 }
 function validatePromises(project, errors) {
   for (const promise of project.promises) {
-    const label = relative(project, promise.file);
+    const label = relative2(project, promise.file);
     const data = readMarkdown(promise.file, project.root).data;
     validateEntityId(promise.id, label, errors);
     requireFields(data, ["title", "status"], label, errors);
@@ -2263,7 +2507,7 @@ function validatePromises(project, errors) {
 }
 function validateGlossaryTerms(project, errors) {
   for (const term of project.glossaryTerms) {
-    const label = relative(project, term.file);
+    const label = relative2(project, term.file);
     const data = readMarkdown(term.file, project.root).data;
     validateEntityId(term.id, label, errors);
     requireFields(data, ["term", "category"], label, errors);
@@ -2367,11 +2611,216 @@ function requireFields(data, fields, label, errors) {
   }
 }
 function chapterNumberFromFile(file) {
-  const match = /chapter-(\d+)/.exec(path.basename(file));
+  const match = /chapter-(\d+)/.exec(path2.basename(file));
   return match ? Number.parseInt(match[1], 10) : 0;
 }
-function relative(project, file) {
-  return path.relative(project.root, file);
+function relative2(project, file) {
+  return path2.relative(project.root, file);
+}
+
+// src/import.js
+var CHAPTER_HEADING_PATTERN = /^chapter\s*(?:\d+|[ivxlc]+)?\s*[:.\-–—]*\s*(.*)$/i;
+var FRONTMATTER_PATTERN2 = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+var CANDIDATE_THRESHOLD = 3;
+var CANDIDATE_LIMIT = 25;
+var CANDIDATE_STOPWORDS = new Set([
+  "A",
+  "An",
+  "And",
+  "At",
+  "But",
+  "By",
+  "Dr",
+  "For",
+  "He",
+  "Her",
+  "His",
+  "I",
+  "If",
+  "In",
+  "It",
+  "Its",
+  "Mr",
+  "Mrs",
+  "Ms",
+  "No",
+  "Not",
+  "Of",
+  "On",
+  "Or",
+  "She",
+  "That",
+  "The",
+  "Then",
+  "They",
+  "Their",
+  "This",
+  "To",
+  "We",
+  "When",
+  "While",
+  "With",
+  "Yes",
+  "You"
+]);
+function importManuscript(options) {
+  const rawSource = String(options.source ?? "").trim();
+  if (!rawSource) {
+    throw new Error("An import source file or directory is required");
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const source = path3.resolve(cwd, rawSource);
+  if (!fs2.existsSync(source)) {
+    throw new Error(`Import source not found: ${source}`);
+  }
+  const chapters = splitChapters(readSourceDocuments(source));
+  if (chapters.length === 0) {
+    throw new Error("No chapter content found in import source");
+  }
+  const created = createStoryProject({
+    title: options.title,
+    cwd,
+    dir: options.dir,
+    genre: options.genre,
+    subGenre: options.subGenre,
+    settingEra: options.settingEra,
+    themes: options.themes,
+    pov: options.pov,
+    tense: options.tense,
+    synopsis: options.synopsis ?? `Imported from ${path3.basename(source)}. Replace with a 2-3 sentence synopsis.`,
+    force: options.force
+  });
+  let totalWords = 0;
+  chapters.forEach((chapter, index) => {
+    const number = index + 1;
+    const words = wordCount(chapter.prose);
+    totalWords += words;
+    const file = path3.join(created.root, "chapters", `chapter-${String(number).padStart(2, "0")}.md`);
+    fs2.writeFileSync(file, chapterMarkdown(chapter.title, number, words, chapter.prose), "utf8");
+  });
+  reindexProject(created.root);
+  return {
+    root: created.root,
+    storyId: created.storyId,
+    chapters: chapters.length,
+    words: totalWords,
+    candidates: extractNameCandidates(chapters.map((chapter) => chapter.prose).join(`
+
+`))
+  };
+}
+function extractNameCandidates(prose) {
+  const counts = new Map;
+  for (const match of prose.matchAll(/\b[A-Z][a-z']+(?:\s+[A-Z][a-z']+)+\b/g)) {
+    const words = match[0].replace(/\s+/g, " ").split(" ");
+    while (words.length > 0 && CANDIDATE_STOPWORDS.has(words[0])) {
+      words.shift();
+    }
+    if (words.length > 0) {
+      addCandidate(counts, words.join(" "));
+    }
+  }
+  for (const match of prose.matchAll(/(?<=[a-z][,;:]?\s)(?<![A-Z][a-z']*\s)[A-Z][a-z']+\b(?!\s+[A-Z][a-z'])/g)) {
+    if (!CANDIDATE_STOPWORDS.has(match[0])) {
+      addCandidate(counts, match[0]);
+    }
+  }
+  return [...counts.entries()].filter(([, count]) => count >= CANDIDATE_THRESHOLD).sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0])).slice(0, CANDIDATE_LIMIT).map(([name, count]) => ({ name, count }));
+}
+function addCandidate(counts, name) {
+  counts.set(name, (counts.get(name) ?? 0) + 1);
+}
+function readSourceDocuments(source) {
+  if (fs2.statSync(source).isFile()) {
+    return [{ name: path3.basename(source), text: fs2.readFileSync(source, "utf8") }];
+  }
+  const documents = fs2.readdirSync(source, { withFileTypes: true }).filter((entry) => entry.isFile() && /\.(md|markdown|txt)$/i.test(entry.name)).map((entry) => entry.name).sort().map((name) => ({ name, text: fs2.readFileSync(path3.join(source, name), "utf8") }));
+  if (documents.length === 0) {
+    throw new Error(`No markdown or text files found in ${source}`);
+  }
+  return documents;
+}
+function splitChapters(documents) {
+  const chapters = [];
+  for (const document of documents) {
+    const text = document.text.replace(FRONTMATTER_PATTERN2, "").replace(/\r\n/g, `
+`);
+    const sections = splitByChapterHeadings(text);
+    if (sections.length > 0) {
+      chapters.push(...sections);
+    } else {
+      chapters.push(singleChapter(text, document.name));
+    }
+  }
+  return chapters.filter((chapter) => chapter.prose !== "");
+}
+function splitByChapterHeadings(text) {
+  const lines = text.split(`
+`);
+  const sections = [];
+  let current = null;
+  const preamble = [];
+  for (const line of lines) {
+    const heading = /^#{1,6}\s+(.*)$/.exec(line);
+    const chapterMatch = heading ? CHAPTER_HEADING_PATTERN.exec(heading[1].trim()) : null;
+    if (chapterMatch) {
+      if (current) {
+        sections.push(finishChapter(current));
+      }
+      current = { title: chapterMatch[1].trim() || heading[1].trim(), lines: [] };
+    } else if (current) {
+      current.lines.push(line);
+    } else {
+      preamble.push(line);
+    }
+  }
+  if (!current) {
+    return [];
+  }
+  sections.push(finishChapter(current));
+  const opening = stripTitleHeading(preamble.join(`
+`)).trim();
+  if (opening !== "") {
+    sections.unshift({ title: "Opening", prose: opening });
+  }
+  return sections;
+}
+function finishChapter(section) {
+  return { title: section.title, prose: section.lines.join(`
+`).trim() };
+}
+function singleChapter(text, fileName) {
+  const headingMatch = /^#\s+(.*)$/m.exec(text);
+  if (headingMatch) {
+    return {
+      title: headingMatch[1].trim(),
+      prose: text.slice(headingMatch.index + headingMatch[0].length).trim()
+    };
+  }
+  return {
+    title: titleCaseSlug(path3.basename(fileName, path3.extname(fileName))),
+    prose: text.trim()
+  };
+}
+function stripTitleHeading(text) {
+  return text.replace(/^\s*#\s+[^\n]*\n?/, "");
+}
+function chapterMarkdown(title, number, words, prose) {
+  return `${stringifyFrontmatter({
+    title,
+    number,
+    pov: "",
+    locations: [],
+    characters: [],
+    "arcs-advanced": [],
+    status: "draft",
+    "word-count": words
+  })}# Chapter ${number}: ${title}
+
+## Chapter Text
+
+${prose}
+`;
 }
 
 // src/cli.js
@@ -2379,10 +2828,13 @@ var HELP = `Usage: story <command> [options]
 
 Commands:
   init <title>       Scaffold a story project
+  import <source>    Split an existing manuscript into a new story project
   validate [path]    Check project structure, frontmatter, and registries
   reindex [path]     Rebuild registry tables from markdown files
   wordcount [path]   Count chapter prose words
   links [path]       Check cross-reference targets and backlinks
+  continuity [path]  Check deterministic continuity contracts: deaths,
+                    promises, questions, casts, and durable state
   report [path]      Summarize project inventory, progress, and checks
   next [path]        Recommend the next writing and maintenance actions
   doctor [path]      Show health checks plus actionable repair steps
@@ -2396,7 +2848,8 @@ Commands:
   build [path]       Build a disposable book artifact in dist/
 
 Options:
-  --dir <path>              Target directory for init
+  --title <name>            Story title for import
+  --dir <path>              Target directory for init or import
   --genre <name>            Story genre for init
   --sub-genre <name>        Story sub-genre for init
   --setting-era <name>      Setting era for init
@@ -2460,12 +2913,42 @@ function runCli(argv, io) {
 `);
       return 0;
     }
-    const root = path2.resolve(cwd, parsed.positionals[1] ?? ".");
+    if (command === "import") {
+      const result = importManuscript({
+        source: parsed.positionals[1],
+        title: parsed.options.title,
+        cwd,
+        dir: parsed.options.dir,
+        genre: parsed.options.genre,
+        subGenre: parsed.options["sub-genre"],
+        settingEra: parsed.options["setting-era"],
+        themes: collectThemes(parsed.options),
+        pov: parsed.options.pov,
+        tense: parsed.options.tense,
+        synopsis: parsed.options.synopsis,
+        force: Boolean(parsed.options.force)
+      });
+      io.stdout.write(`Imported ${result.chapters} chapters (${result.words} words) into ${result.root}
+`);
+      if (result.candidates.length > 0) {
+        io.stdout.write(`Entity candidates (review, then create with story add):
+`);
+        for (const candidate of result.candidates) {
+          io.stdout.write(`- ${candidate.name} (${candidate.count} mentions)
+`);
+        }
+      }
+      return 0;
+    }
+    const root = path4.resolve(cwd, parsed.positionals[1] ?? ".");
     if (command === "validate") {
-      return reportResult(io, validateProject(root), "Project is valid");
+      return reportResult(io, validateProject(root), "Project is valid", "Project validation failed");
     }
     if (command === "links") {
-      return reportResult(io, validateLinks(root), "Links are valid");
+      return reportResult(io, validateLinks(root), "Links are valid", "Link check failed");
+    }
+    if (command === "continuity") {
+      return reportResult(io, checkProjectContinuity(root), "Continuity is consistent", "Continuity check failed");
     }
     if (command === "report") {
       io.stdout.write(formatProjectReport(projectReport(root), { actionable: Boolean(parsed.options.actionable) }));
@@ -2593,11 +3076,11 @@ function collectThemes(options) {
   return [].concat(options.theme ?? []).concat(options.themes ?? []).filter((value) => value !== undefined && value !== true);
 }
 function targetRoot(cwd, parsed) {
-  return path2.resolve(cwd, parsed.options.path ?? ".");
+  return path4.resolve(cwd, parsed.options.path ?? ".");
 }
-function reportResult(io, result, successMessage) {
+function reportResult(io, result, successMessage, failureMessage) {
   const output = result.ok ? io.stdout : io.stderr;
-  output.write(`${successMessage}: ${result.errors.length} errors, ${result.warnings.length} warnings
+  output.write(`${result.ok ? successMessage : failureMessage}: ${result.errors.length} errors, ${result.warnings.length} warnings
 `);
   for (const error of result.errors) {
     io.stderr.write(`error: ${error}

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,8 @@
 import path from "node:path";
+import { importManuscript } from "./import.js";
 import {
   buildBook,
+  checkProjectContinuity,
   computeWordCounts,
   createEntity,
   createStoryProject,
@@ -22,10 +24,13 @@ const HELP = `Usage: story <command> [options]
 
 Commands:
   init <title>       Scaffold a story project
+  import <source>    Split an existing manuscript into a new story project
   validate [path]    Check project structure, frontmatter, and registries
   reindex [path]     Rebuild registry tables from markdown files
   wordcount [path]   Count chapter prose words
   links [path]       Check cross-reference targets and backlinks
+  continuity [path]  Check deterministic continuity contracts: deaths,
+                    promises, questions, casts, and durable state
   report [path]      Summarize project inventory, progress, and checks
   next [path]        Recommend the next writing and maintenance actions
   doctor [path]      Show health checks plus actionable repair steps
@@ -39,7 +44,8 @@ Commands:
   build [path]       Build a disposable book artifact in dist/
 
 Options:
-  --dir <path>              Target directory for init
+  --title <name>            Story title for import
+  --dir <path>              Target directory for init or import
   --genre <name>            Story genre for init
   --sub-genre <name>        Story sub-genre for init
   --setting-era <name>      Setting era for init
@@ -106,13 +112,42 @@ export function runCli(argv, io) {
       return 0;
     }
 
+    if (command === "import") {
+      const result = importManuscript({
+        source: parsed.positionals[1],
+        title: parsed.options.title,
+        cwd,
+        dir: parsed.options.dir,
+        genre: parsed.options.genre,
+        subGenre: parsed.options["sub-genre"],
+        settingEra: parsed.options["setting-era"],
+        themes: collectThemes(parsed.options),
+        pov: parsed.options.pov,
+        tense: parsed.options.tense,
+        synopsis: parsed.options.synopsis,
+        force: Boolean(parsed.options.force)
+      });
+      io.stdout.write(`Imported ${result.chapters} chapters (${result.words} words) into ${result.root}\n`);
+      if (result.candidates.length > 0) {
+        io.stdout.write("Entity candidates (review, then create with story add):\n");
+        for (const candidate of result.candidates) {
+          io.stdout.write(`- ${candidate.name} (${candidate.count} mentions)\n`);
+        }
+      }
+      return 0;
+    }
+
     const root = path.resolve(cwd, parsed.positionals[1] ?? ".");
     if (command === "validate") {
-      return reportResult(io, validateProject(root), "Project is valid");
+      return reportResult(io, validateProject(root), "Project is valid", "Project validation failed");
     }
 
     if (command === "links") {
-      return reportResult(io, validateLinks(root), "Links are valid");
+      return reportResult(io, validateLinks(root), "Links are valid", "Link check failed");
+    }
+
+    if (command === "continuity") {
+      return reportResult(io, checkProjectContinuity(root), "Continuity is consistent", "Continuity check failed");
     }
 
     if (command === "report") {
@@ -257,9 +292,9 @@ function targetRoot(cwd, parsed) {
   return path.resolve(cwd, parsed.options.path ?? ".");
 }
 
-function reportResult(io, result, successMessage) {
+function reportResult(io, result, successMessage, failureMessage) {
   const output = result.ok ? io.stdout : io.stderr;
-  output.write(`${successMessage}: ${result.errors.length} errors, ${result.warnings.length} warnings\n`);
+  output.write(`${result.ok ? successMessage : failureMessage}: ${result.errors.length} errors, ${result.warnings.length} warnings\n`);
 
   for (const error of result.errors) {
     io.stderr.write(`error: ${error}\n`);

--- a/src/continuity.js
+++ b/src/continuity.js
@@ -1,0 +1,259 @@
+import path from "node:path";
+
+const CHEKHOV_CHAPTER_GAP = 3;
+
+export function checkContinuity(project) {
+  const errors = [];
+  const warnings = [];
+  const context = {
+    chapterNumbers: new Map(project.chapters.map((chapter) => [chapter.id, chapter.number])),
+    characters: new Map(project.characters.map((character) => [character.id, character])),
+    locations: new Set(project.locations.map((location) => location.id)),
+    artifacts: new Map(project.artifacts.map((artifact) => [artifact.id, artifact])),
+    factions: new Set(project.factions.map((faction) => faction.id)),
+    latestChapter: project.chapters.reduce((max, chapter) => Math.max(max, chapter.number), 0)
+  };
+
+  checkCharacterDeaths(project, context, errors);
+  checkChapterCasts(project, warnings);
+  checkSceneCasts(project, warnings);
+  checkChapterSequence(project, warnings);
+  checkPromises(project, context, errors, warnings);
+  checkQuestions(project, context, errors);
+  checkStoryCompletion(project, errors);
+  checkContinuityState(project, context, errors, warnings);
+
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+function checkCharacterDeaths(project, context, errors) {
+  for (const character of project.characters) {
+    if (!character.diedIn) {
+      continue;
+    }
+
+    const label = relative(project, character.file);
+    if (character.status !== "deceased") {
+      errors.push(`${label} has died-in ${character.diedIn} but status ${character.status || "unset"}; set status: deceased`);
+    }
+
+    const deathNumber = context.chapterNumbers.get(character.diedIn);
+    if (deathNumber === undefined) {
+      errors.push(`${label} died-in references missing chapter ${character.diedIn}`);
+      continue;
+    }
+
+    for (const chapter of project.chapters) {
+      if (chapter.number > deathNumber && castIncludes(chapter, character.id)) {
+        errors.push(`${relative(project, chapter.file)} lists ${character.id}, who died in ${character.diedIn}; move posthumous appearances to mentions`);
+      }
+    }
+
+    for (const scene of project.scenes) {
+      const sceneChapterNumber = context.chapterNumbers.get(scene.chapter);
+      if (sceneChapterNumber !== undefined && sceneChapterNumber > deathNumber && castIncludes(scene, character.id)) {
+        errors.push(`${relative(project, scene.file)} lists ${character.id}, who died in ${character.diedIn}; move posthumous appearances to mentions`);
+      }
+    }
+  }
+}
+
+function checkChapterCasts(project, warnings) {
+  for (const chapter of project.chapters) {
+    if (chapter.pov && !chapter.characters.includes(chapter.pov)) {
+      warnings.push(`${relative(project, chapter.file)} POV character ${chapter.pov} is not listed in characters`);
+    }
+  }
+}
+
+function checkSceneCasts(project, warnings) {
+  const chapters = new Map(project.chapters.map((chapter) => [chapter.id, chapter]));
+
+  for (const scene of project.scenes) {
+    const label = relative(project, scene.file);
+    if (scene.pov && !scene.characters.includes(scene.pov)) {
+      warnings.push(`${label} POV character ${scene.pov} is not listed in characters`);
+    }
+
+    const chapter = chapters.get(scene.chapter);
+    if (!chapter) {
+      continue;
+    }
+
+    for (const characterId of scene.characters) {
+      if (!chapter.characters.includes(characterId) && !chapter.mentions.includes(characterId)) {
+        warnings.push(`${label} lists ${characterId} but ${relative(project, chapter.file)} does not list them in characters or mentions`);
+      }
+    }
+
+    if (scene.location && chapter.locations.length > 0 && !chapter.locations.includes(scene.location)) {
+      warnings.push(`${label} is set in ${scene.location} but ${relative(project, chapter.file)} does not list that location`);
+    }
+  }
+}
+
+function checkChapterSequence(project, warnings) {
+  const numbers = project.chapters
+    .map((chapter) => chapter.number)
+    .filter((number) => Number.isInteger(number) && number > 0)
+    .sort((left, right) => left - right);
+
+  for (let index = 1; index < numbers.length; index += 1) {
+    if (numbers[index] > numbers[index - 1] + 1) {
+      warnings.push(`Chapter numbering skips from ${numbers[index - 1]} to ${numbers[index]}`);
+    }
+  }
+}
+
+function checkPromises(project, context, errors, warnings) {
+  for (const promise of project.promises) {
+    const label = relative(project, promise.file);
+    const plantedNumber = context.chapterNumbers.get(promise.planted);
+    const payoffNumber = context.chapterNumbers.get(promise.payoff);
+
+    if (plantedNumber !== undefined && payoffNumber !== undefined && payoffNumber < plantedNumber) {
+      errors.push(`${label} pays off in ${promise.payoff} before it is planted in ${promise.planted}`);
+    }
+
+    if (promise.status === "paid-off" && !promise.payoff) {
+      errors.push(`${label} is paid-off but has no payoff chapter`);
+    }
+
+    if (promise.status === "planted" && !promise.planted) {
+      errors.push(`${label} is planted but has no planted chapter`);
+    }
+
+    if (promise.status === "planned" && promise.planted) {
+      warnings.push(`${label} records planted chapter ${promise.planted} but status is still planned`);
+    }
+
+    if (promise.status === "planted" && plantedNumber !== undefined && context.latestChapter - plantedNumber >= CHEKHOV_CHAPTER_GAP) {
+      warnings.push(`${label} was planted in ${promise.planted}, ${context.latestChapter - plantedNumber} chapters ago, and has no payoff yet`);
+    }
+  }
+}
+
+function checkQuestions(project, context, errors) {
+  for (const question of project.questions) {
+    const label = relative(project, question.file);
+    const introducedNumber = context.chapterNumbers.get(question.introduced);
+    const resolvedNumber = context.chapterNumbers.get(question.resolved);
+
+    if (introducedNumber !== undefined && resolvedNumber !== undefined && resolvedNumber < introducedNumber) {
+      errors.push(`${label} resolves in ${question.resolved} before it is introduced in ${question.introduced}`);
+    }
+
+    if ((question.status === "answered" || question.status === "resolved") && !question.resolved) {
+      errors.push(`${label} is ${question.status} but has no resolved chapter`);
+    }
+
+    if (question.status === "open" && question.resolved) {
+      errors.push(`${label} records resolved chapter ${question.resolved} but status is still open`);
+    }
+  }
+}
+
+function checkStoryCompletion(project, errors) {
+  if (project.story.data.status !== "complete") {
+    return;
+  }
+
+  for (const promise of project.promises) {
+    if (promise.status === "planned" || promise.status === "planted") {
+      errors.push(`story.md is complete but ${relative(project, promise.file)} is still ${promise.status}`);
+    }
+  }
+
+  for (const question of project.questions) {
+    if (question.status === "open") {
+      errors.push(`story.md is complete but ${relative(project, question.file)} is still open`);
+    }
+  }
+}
+
+function checkContinuityState(project, context, errors, warnings) {
+  if (!project.continuity) {
+    return;
+  }
+
+  const label = path.join("continuity", "state.md");
+  const data = project.continuity.data;
+  const currentChapter = data["current-chapter"];
+
+  if (Number.isInteger(currentChapter)) {
+    if (currentChapter > context.latestChapter) {
+      errors.push(`${label} current-chapter ${currentChapter} is ahead of the latest chapter ${context.latestChapter}`);
+    } else if (currentChapter < context.latestChapter) {
+      warnings.push(`${label} current-chapter ${currentChapter} is behind the latest chapter ${context.latestChapter}; update continuity state after drafting`);
+    }
+  }
+
+  for (const [index, entry] of stateEntries(data["character-state"]).entries()) {
+    const entryLabel = `${label} character-state[${index}]`;
+    if (!requireMapping(entry, entryLabel, errors)) {
+      continue;
+    }
+    if (!entry.character || !context.characters.has(entry.character)) {
+      errors.push(`${entryLabel} references missing character ${entry.character || "(unset)"}`);
+    }
+    if (entry.location && !context.locations.has(entry.location)) {
+      errors.push(`${entryLabel} references missing location ${entry.location}`);
+    }
+  }
+
+  for (const [index, entry] of stateEntries(data["knowledge-state"]).entries()) {
+    const entryLabel = `${label} knowledge-state[${index}]`;
+    if (!requireMapping(entry, entryLabel, errors)) {
+      continue;
+    }
+    if (!entry.character || !context.characters.has(entry.character)) {
+      errors.push(`${entryLabel} references missing character ${entry.character || "(unset)"}`);
+    }
+    if (!entry.knows) {
+      errors.push(`${entryLabel} is missing knows`);
+    }
+    if (entry["learned-in"] && !context.chapterNumbers.has(entry["learned-in"])) {
+      errors.push(`${entryLabel} references missing chapter ${entry["learned-in"]}`);
+    }
+  }
+
+  for (const [index, entry] of stateEntries(data["object-state"]).entries()) {
+    const entryLabel = `${label} object-state[${index}]`;
+    if (!requireMapping(entry, entryLabel, errors)) {
+      continue;
+    }
+    const artifact = context.artifacts.get(entry.artifact);
+    if (!entry.artifact || !artifact) {
+      errors.push(`${entryLabel} references missing artifact ${entry.artifact || "(unset)"}`);
+    }
+    if (entry.owner && !context.characters.has(entry.owner) && !context.factions.has(entry.owner)) {
+      errors.push(`${entryLabel} references missing owner ${entry.owner}`);
+    }
+    if (entry.location && !context.locations.has(entry.location)) {
+      errors.push(`${entryLabel} references missing location ${entry.location}`);
+    }
+    if (entry.status && artifact && artifact.status && entry.status !== artifact.status) {
+      warnings.push(`${entryLabel} status ${entry.status} conflicts with ${relative(project, artifact.file)} status ${artifact.status}`);
+    }
+  }
+}
+
+function castIncludes(record, characterId) {
+  return record.pov === characterId || record.characters.includes(characterId);
+}
+
+function stateEntries(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function requireMapping(entry, entryLabel, errors) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    errors.push(`${entryLabel} must be a mapping`);
+    return false;
+  }
+  return true;
+}
+
+function relative(project, file) {
+  return path.relative(project.root, file);
+}

--- a/src/import.js
+++ b/src/import.js
@@ -1,0 +1,205 @@
+import fs from "node:fs";
+import path from "node:path";
+import { stringifyFrontmatter } from "./frontmatter.js";
+import { titleCaseSlug, wordCount } from "./markdown.js";
+import { createStoryProject, reindexProject } from "./story.js";
+
+const CHAPTER_HEADING_PATTERN = /^chapter\s*(?:\d+|[ivxlc]+)?\s*[:.\-–—]*\s*(.*)$/i;
+const FRONTMATTER_PATTERN = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+const CANDIDATE_THRESHOLD = 3;
+const CANDIDATE_LIMIT = 25;
+const CANDIDATE_STOPWORDS = new Set([
+  "A", "An", "And", "At", "But", "By", "Dr", "For", "He", "Her", "His", "I", "If", "In", "It", "Its",
+  "Mr", "Mrs", "Ms", "No", "Not", "Of", "On", "Or", "She", "That", "The", "Then", "They", "Their",
+  "This", "To", "We", "When", "While", "With", "Yes", "You"
+]);
+
+export function importManuscript(options) {
+  const rawSource = String(options.source ?? "").trim();
+  if (!rawSource) {
+    throw new Error("An import source file or directory is required");
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const source = path.resolve(cwd, rawSource);
+  if (!fs.existsSync(source)) {
+    throw new Error(`Import source not found: ${source}`);
+  }
+
+  const chapters = splitChapters(readSourceDocuments(source));
+  if (chapters.length === 0) {
+    throw new Error("No chapter content found in import source");
+  }
+
+  const created = createStoryProject({
+    title: options.title,
+    cwd,
+    dir: options.dir,
+    genre: options.genre,
+    subGenre: options.subGenre,
+    settingEra: options.settingEra,
+    themes: options.themes,
+    pov: options.pov,
+    tense: options.tense,
+    synopsis: options.synopsis ?? `Imported from ${path.basename(source)}. Replace with a 2-3 sentence synopsis.`,
+    force: options.force
+  });
+
+  let totalWords = 0;
+  chapters.forEach((chapter, index) => {
+    const number = index + 1;
+    const words = wordCount(chapter.prose);
+    totalWords += words;
+    const file = path.join(created.root, "chapters", `chapter-${String(number).padStart(2, "0")}.md`);
+    fs.writeFileSync(file, chapterMarkdown(chapter.title, number, words, chapter.prose), "utf8");
+  });
+
+  reindexProject(created.root);
+
+  return {
+    root: created.root,
+    storyId: created.storyId,
+    chapters: chapters.length,
+    words: totalWords,
+    candidates: extractNameCandidates(chapters.map((chapter) => chapter.prose).join("\n\n"))
+  };
+}
+
+export function extractNameCandidates(prose) {
+  const counts = new Map();
+
+  for (const match of prose.matchAll(/\b[A-Z][a-z']+(?:\s+[A-Z][a-z']+)+\b/g)) {
+    const words = match[0].replace(/\s+/g, " ").split(" ");
+    while (words.length > 0 && CANDIDATE_STOPWORDS.has(words[0])) {
+      words.shift();
+    }
+    if (words.length > 0) {
+      addCandidate(counts, words.join(" "));
+    }
+  }
+
+  for (const match of prose.matchAll(/(?<=[a-z][,;:]?\s)(?<![A-Z][a-z']*\s)[A-Z][a-z']+\b(?!\s+[A-Z][a-z'])/g)) {
+    if (!CANDIDATE_STOPWORDS.has(match[0])) {
+      addCandidate(counts, match[0]);
+    }
+  }
+
+  return [...counts.entries()]
+    .filter(([, count]) => count >= CANDIDATE_THRESHOLD)
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, CANDIDATE_LIMIT)
+    .map(([name, count]) => ({ name, count }));
+}
+
+function addCandidate(counts, name) {
+  counts.set(name, (counts.get(name) ?? 0) + 1);
+}
+
+function readSourceDocuments(source) {
+  if (fs.statSync(source).isFile()) {
+    return [{ name: path.basename(source), text: fs.readFileSync(source, "utf8") }];
+  }
+
+  const documents = fs.readdirSync(source, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.(md|markdown|txt)$/i.test(entry.name))
+    .map((entry) => entry.name)
+    .sort()
+    .map((name) => ({ name, text: fs.readFileSync(path.join(source, name), "utf8") }));
+
+  if (documents.length === 0) {
+    throw new Error(`No markdown or text files found in ${source}`);
+  }
+
+  return documents;
+}
+
+function splitChapters(documents) {
+  const chapters = [];
+
+  for (const document of documents) {
+    const text = document.text.replace(FRONTMATTER_PATTERN, "").replace(/\r\n/g, "\n");
+    const sections = splitByChapterHeadings(text);
+    if (sections.length > 0) {
+      chapters.push(...sections);
+    } else {
+      chapters.push(singleChapter(text, document.name));
+    }
+  }
+
+  return chapters.filter((chapter) => chapter.prose !== "");
+}
+
+function splitByChapterHeadings(text) {
+  const lines = text.split("\n");
+  const sections = [];
+  let current = null;
+  const preamble = [];
+
+  for (const line of lines) {
+    const heading = /^#{1,6}\s+(.*)$/.exec(line);
+    const chapterMatch = heading ? CHAPTER_HEADING_PATTERN.exec(heading[1].trim()) : null;
+    if (chapterMatch) {
+      if (current) {
+        sections.push(finishChapter(current));
+      }
+      current = { title: chapterMatch[1].trim() || heading[1].trim(), lines: [] };
+    } else if (current) {
+      current.lines.push(line);
+    } else {
+      preamble.push(line);
+    }
+  }
+
+  if (!current) {
+    return [];
+  }
+
+  sections.push(finishChapter(current));
+  const opening = stripTitleHeading(preamble.join("\n")).trim();
+  if (opening !== "") {
+    sections.unshift({ title: "Opening", prose: opening });
+  }
+
+  return sections;
+}
+
+function finishChapter(section) {
+  return { title: section.title, prose: section.lines.join("\n").trim() };
+}
+
+function singleChapter(text, fileName) {
+  const headingMatch = /^#\s+(.*)$/m.exec(text);
+  if (headingMatch) {
+    return {
+      title: headingMatch[1].trim(),
+      prose: text.slice(headingMatch.index + headingMatch[0].length).trim()
+    };
+  }
+
+  return {
+    title: titleCaseSlug(path.basename(fileName, path.extname(fileName))),
+    prose: text.trim()
+  };
+}
+
+function stripTitleHeading(text) {
+  return text.replace(/^\s*#\s+[^\n]*\n?/, "");
+}
+
+function chapterMarkdown(title, number, words, prose) {
+  return `${stringifyFrontmatter({
+    title,
+    number,
+    pov: "",
+    locations: [],
+    characters: [],
+    "arcs-advanced": [],
+    status: "draft",
+    "word-count": words
+  })}# Chapter ${number}: ${title}
+
+## Chapter Text
+
+${prose}
+`;
+}

--- a/src/story.js
+++ b/src/story.js
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import fs from "node:fs";
 import path from "node:path";
+import { checkContinuity } from "./continuity.js";
 import { parseFrontmatter, replaceFrontmatter, stringifyFrontmatter } from "./frontmatter.js";
 import { chapterProse, escapeRegExp, extractSection, kebabCase, titleCaseSlug, wordCount } from "./markdown.js";
 
@@ -151,6 +152,7 @@ export function scanProject(root) {
       name: data.name ?? titleCaseSlug(id),
       role: data.role ?? "",
       status: data.status ?? "",
+      diedIn: data["died-in"] ?? "",
       relationships: asArray(data.relationships),
       locations: asArray(data.locations)
     })),
@@ -203,6 +205,7 @@ export function scanProject(root) {
       pov: data.pov ?? "",
       status: data.status ?? "",
       characters: asArray(data.characters),
+      mentions: asArray(data.mentions),
       locations: asArray(data.locations),
       arcsAdvanced: asArray(data["arcs-advanced"]),
       declaredWordCount: Number(data["word-count"] ?? 0),
@@ -218,6 +221,7 @@ export function scanProject(root) {
       location: data.location ?? "",
       status: data.status ?? "",
       characters: asArray(data.characters),
+      mentions: asArray(data.mentions),
       arcsAdvanced: asArray(data["arcs-advanced"]),
       stateChanges: asArray(data["state-changes"])
     })).sort((left, right) => left.chapter.localeCompare(right.chapter) || left.scene - right.scene || left.file.localeCompare(right.file)),
@@ -378,7 +382,7 @@ export function validateLinks(root) {
       errors.push(`${relative(project, chapter.file)} references missing POV character ${chapter.pov}`);
     }
 
-    for (const characterId of chapter.characters) {
+    for (const characterId of chapter.characters.concat(chapter.mentions)) {
       if (!characters.has(characterId)) {
         errors.push(`${relative(project, chapter.file)} references missing character ${characterId}`);
       }
@@ -427,7 +431,7 @@ export function validateLinks(root) {
     if (scene.location && !locations.has(scene.location)) {
       errors.push(`${relative(project, scene.file)} references missing location ${scene.location}`);
     }
-    for (const characterId of scene.characters) {
+    for (const characterId of scene.characters.concat(scene.mentions)) {
       if (!characters.has(characterId)) {
         errors.push(`${relative(project, scene.file)} references missing character ${characterId}`);
       }
@@ -473,10 +477,15 @@ export function validateLinks(root) {
   return { ok: errors.length === 0, errors, warnings };
 }
 
+export function checkProjectContinuity(root) {
+  return checkContinuity(scanProject(root));
+}
+
 export function projectReport(root) {
   const project = scanProject(root);
   const validation = validateProject(project.root);
   const links = validateLinks(project.root);
+  const continuity = checkContinuity(project);
   const totalWords = project.chapters.reduce((sum, chapter) => sum + chapter.wordCount, 0);
 
   return {
@@ -518,7 +527,8 @@ export function projectReport(root) {
     })),
     validation,
     links,
-    actions: buildProjectActions(project, validation, links)
+    continuity,
+    actions: buildProjectActions(project, validation, links, continuity)
   };
 }
 
@@ -570,7 +580,8 @@ export function formatProjectReport(report, options = {}) {
     "",
     "Checks:",
     `- Validate: ${formatCheck(report.validation)}`,
-    `- Links: ${formatCheck(report.links)}`
+    `- Links: ${formatCheck(report.links)}`,
+    `- Continuity: ${formatCheck(report.continuity)}`
   );
 
   if (options.actionable) {
@@ -585,13 +596,15 @@ export function projectActions(root) {
   const project = scanProject(root);
   const validation = validateProject(project.root);
   const links = validateLinks(project.root);
+  const continuity = checkContinuity(project);
   return {
     root: project.root,
     title: project.story.data.title,
     storyId: project.storyId,
-    actions: buildProjectActions(project, validation, links),
+    actions: buildProjectActions(project, validation, links, continuity),
     validation,
-    links
+    links,
+    continuity
   };
 }
 
@@ -599,7 +612,7 @@ export function formatActionReport(report) {
   const lines = [
     `# Next Writing Actions: ${report.title}`,
     "",
-    `Checks: validate ${formatCheck(report.validation)}, links ${formatCheck(report.links)}`,
+    `Checks: validate ${formatCheck(report.validation)}, links ${formatCheck(report.links)}, continuity ${formatCheck(report.continuity)}`,
     "",
     "Actions:"
   ];
@@ -616,6 +629,7 @@ export function formatDoctorReport(report) {
     "Checks:",
     `- Validate: ${formatCheck(report.validation)}`,
     `- Links: ${formatCheck(report.links)}`,
+    `- Continuity: ${formatCheck(report.continuity)}`,
     "",
     "Actions:"
   ];
@@ -1098,13 +1112,19 @@ ${rows.join("\n")}
 `;
 }
 
-function buildProjectActions(project, validation, links) {
+function buildProjectActions(project, validation, links, continuity) {
   const actions = [];
   if (validation.errors.length > 0) {
     actions.push(action("P0", "Fix validation errors", `Run story validate . and repair ${validation.errors.length} schema or registry errors.`));
   }
   if (links.errors.length > 0) {
     actions.push(action("P0", "Fix broken references", `Run story links . and repair ${links.errors.length} missing references or backlinks.`));
+  }
+  if (continuity.errors.length > 0) {
+    actions.push(action("P0", "Fix continuity contradictions", `Run story continuity . and repair ${continuity.errors.length} deterministic continuity errors.`));
+  }
+  if (continuity.warnings.length > 0) {
+    actions.push(action("P1", "Review continuity warnings", `Run story continuity . and review ${continuity.warnings.length} continuity warnings.`));
   }
   const staleChapters = [];
   const chaptersWithoutScenes = [];
@@ -1161,7 +1181,7 @@ function buildProjectActions(project, validation, links) {
   if (project.characters.length === 0) {
     actions.push(action("P2", "Create first character", "Use story add character \"Name\" --role protagonist before drafting prose."));
   }
-  if (actions.length === 1 && validation.ok && links.ok && staleChapters.length === 0 && chaptersWithoutScenes.length === 0) {
+  if (actions.length === 1 && validation.ok && links.ok && continuity.ok && continuity.warnings.length === 0 && staleChapters.length === 0 && chaptersWithoutScenes.length === 0) {
     actions.unshift(action("P3", "Project is mechanically healthy", "No deterministic maintenance issues are blocking the next writing pass."));
   }
   return actions;
@@ -2110,6 +2130,9 @@ function validateCharacters(project, errors) {
     requireScalar(data, "status", label, errors);
     validateEnum(data, "role", CHARACTER_ROLES, label, errors);
     validateEnum(data, "status", CHARACTER_STATUSES, label, errors);
+    if (data["died-in"] !== undefined) {
+      requireScalar(data, "died-in", label, errors);
+    }
     validateStringArray(data, "aliases", label, errors);
     validateStringArray(data, "locations", label, errors);
     validateStringArray(data, "tags", label, errors);
@@ -2211,6 +2234,7 @@ function validateChapters(project, errors) {
     validateEnum(data, "status", CHAPTER_STATUSES, label, errors);
     validateStringArray(data, "locations", label, errors);
     validateStringArray(data, "characters", label, errors);
+    validateStringArray(data, "mentions", label, errors);
     validateStringArray(data, "arcs-advanced", label, errors);
     if (data.pov !== undefined) {
       requireScalar(data, "pov", label, errors);
@@ -2252,6 +2276,7 @@ function validateScenes(project, errors) {
     requireInteger(data, "scene", label, errors);
     validateEnum(data, "status", SCENE_STATUSES, label, errors);
     validateStringArray(data, "characters", label, errors);
+    validateStringArray(data, "mentions", label, errors);
     validateStringArray(data, "arcs-advanced", label, errors);
     validateObjectArray(data, "state-changes", label, errors);
     if (data.pov !== undefined) {

--- a/templates/github/draft-next-chapter.yml
+++ b/templates/github/draft-next-chapter.yml
@@ -1,0 +1,75 @@
+# Draft the next chapter - write a book via pull requests.
+#
+# Copy this file to .github/workflows/draft-next-chapter.yml in the repository
+# that holds your story project. On each run (scheduled or manual), Claude reads
+# the story bible, asks the Story CLI for the next deterministic action, drafts
+# the next chapter, runs the maintenance checks, and opens a pull request.
+# You review the chapter like any other PR; the story-checks workflow keeps
+# continuity errors from merging.
+#
+# Setup:
+#   1. Add an ANTHROPIC_API_KEY repository secret.
+#   2. Install the Story Skills plugin files so the agent has the workflows:
+#      npx skills add danjdewhurst/story-skills  (or commit skills/ to .claude/skills/)
+#   3. Adjust STORY_DIR and the cron schedule to taste.
+#
+# See https://github.com/anthropics/claude-code-action for action options.
+
+name: Draft the next chapter
+
+on:
+  schedule:
+    - cron: "0 6 * * 1-5" # weekday mornings
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  STORY_DIR: "."
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Draft the next chapter
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are drafting the next chapter of the story project in $STORY_DIR.
+            Work on a new branch named draft/chapter-<next-number>.
+
+            1. Run `npx --yes --package story-skills story next "$STORY_DIR"` and
+               read story.md, chapters/_index.md, continuity/state.md, open
+               questions, promises, and the active arc files.
+            2. If the next actions report any P0 maintenance issues, fix those
+               first and stop after opening a maintenance PR.
+            3. Otherwise draft the next chapter following the chapter-writing
+               skill: outline first, then prose under "## Chapter Text", with
+               accurate frontmatter (pov, locations, characters, arcs-advanced).
+               Add matching scene records and update continuity/state.md,
+               promises, questions, and the timeline.
+            4. Run the maintenance commands and make them pass:
+               npx --yes --package story-skills story wordcount "$STORY_DIR" --write
+               npx --yes --package story-skills story reindex "$STORY_DIR"
+               npx --yes --package story-skills story validate "$STORY_DIR"
+               npx --yes --package story-skills story links "$STORY_DIR"
+               npx --yes --package story-skills story continuity "$STORY_DIR"
+            5. Commit, push the branch, and open a pull request titled
+               "Draft chapter <number>: <title>" summarizing the beats, the arcs
+               advanced, and any promises planted or paid off.
+          claude_args: |
+            --allowedTools "Bash(npx:*),Bash(git:*),Bash(gh pr create:*),Read,Write,Edit,Glob,Grep"

--- a/templates/github/story-checks.yml
+++ b/templates/github/story-checks.yml
@@ -1,0 +1,42 @@
+# Story checks - CI for a Story Skills project repository.
+#
+# Copy this file to .github/workflows/story-checks.yml in the repository that
+# holds your story project. Every push and pull request then runs the
+# deterministic Story CLI checks, so a chapter PR cannot merge with broken
+# registries, dangling references, or continuity contradictions.
+#
+# If your story project lives in a subdirectory, change STORY_DIR.
+
+name: Story checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  STORY_DIR: "."
+
+jobs:
+  story-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate structure, frontmatter, and registries
+        run: npx --yes --package story-skills story validate "$STORY_DIR"
+
+      - name: Check cross-references and backlinks
+        run: npx --yes --package story-skills story links "$STORY_DIR"
+
+      - name: Check continuity contracts
+        run: npx --yes --package story-skills story continuity "$STORY_DIR"
+
+      - name: Report project health
+        run: npx --yes --package story-skills story report "$STORY_DIR" --actionable

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -38,6 +38,9 @@ describe("cli", () => {
     expect(invoke(cwd, ["help"]).out).toContain("Commands:");
     const help = invoke(cwd, ["--help"]).out;
     expect(help).toContain("validate");
+    expect(help).toContain("continuity [path]");
+    expect(help).toContain("import <source>");
+    expect(help).toContain("--title <name>");
     expect(help).toContain("--role <name>");
     expect(help).toContain("--introduced <id>");
     expect(help).toContain("--category <name>");
@@ -153,6 +156,42 @@ word-count: 0
     expect(migrated.code).toBe(0);
     expect(migrated.out).toContain("Migrated project");
     expect(fs.existsSync(path.join(root, "scenes", "_index.md"))).toBe(true);
+  });
+
+  test("runs continuity and import commands", () => {
+    const cwd = makeTempDir();
+    expect(invoke(cwd, ["init", "Checked"]).code).toBe(0);
+    const root = path.join(cwd, "checked");
+    addMinimalChapter(root);
+
+    const clean = invoke(cwd, ["continuity", root]);
+    expect(clean.code).toBe(0);
+    expect(clean.out).toContain("Continuity is consistent");
+
+    writeMarkdown(path.join(root, "continuity", "promises", "ghost-payoff.md"), `
+title: Ghost Payoff
+status: paid-off
+planted: ""
+payoff: ""
+`, "# Ghost Payoff\n");
+    const broken = invoke(cwd, ["continuity", root]);
+    expect(broken.code).toBe(1);
+    expect(broken.err).toContain("ghost-payoff.md is paid-off but has no payoff chapter");
+
+    fs.writeFileSync(path.join(cwd, "book.md"), "## Chapter 1: Door\n\nThe door held fast.\n\n## Chapter 2: Smoke\n\nSmoke crept under it.", "utf8");
+    const imported = invoke(cwd, ["import", "book.md", "--title", "Imported Tale", "--genre", "mystery"]);
+    expect(imported.code).toBe(0);
+    expect(imported.out).toContain("Imported 2 chapters");
+    expect(invoke(cwd, ["validate", path.join(cwd, "imported-tale")]).code).toBe(0);
+
+    fs.writeFileSync(path.join(cwd, "names.md"), "## Chapter 1\n\nHe met Vex Marrow. She trusted Vex Marrow. They feared Vex Marrow.", "utf8");
+    const withCandidates = invoke(cwd, ["import", "names.md", "--title", "Named Tale"]);
+    expect(withCandidates.out).toContain("Entity candidates");
+    expect(withCandidates.out).toContain("- Vex Marrow (3 mentions)");
+
+    const failed = invoke(cwd, ["import"]);
+    expect(failed.code).toBe(1);
+    expect(failed.err).toContain("An import source file or directory is required");
   });
 
   test("prints validation warnings on successful validation", () => {

--- a/test/continuity.test.js
+++ b/test/continuity.test.js
@@ -1,0 +1,362 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { checkContinuity } from "../src/continuity.js";
+import {
+  checkProjectContinuity,
+  createStoryProject,
+  formatActionReport,
+  projectActions,
+  scanProject,
+  validateLinks,
+  validateProject
+} from "../src/story.js";
+import { makeTempDir, writeMarkdown } from "./helpers.js";
+
+function writeChapter(root, number, frontmatter) {
+  writeMarkdown(path.join(root, "chapters", `chapter-${String(number).padStart(2, "0")}.md`), `
+title: Chapter ${number}
+number: ${number}
+${frontmatter.trim()}
+status: draft
+word-count: 0
+`, `# Chapter ${number}\n\n## Chapter Text\n\nWords.\n`);
+}
+
+describe("continuity checks", () => {
+  test("flags dead characters, cast mismatches, and numbering gaps", () => {
+    const cwd = makeTempDir();
+    const created = createStoryProject({ cwd, title: "Deaths", force: false });
+    const root = created.root;
+
+    writeMarkdown(path.join(root, "characters", "edran-vale.md"), `
+name: Edran Vale
+role: supporting
+status: deceased
+died-in: chapter-01
+`, "# Edran\n");
+    writeMarkdown(path.join(root, "characters", "liv-marsh.md"), `
+name: Liv Marsh
+role: supporting
+status: alive
+died-in: chapter-01
+`, "# Liv\n");
+    writeMarkdown(path.join(root, "characters", "ghost-orin.md"), `
+name: Ghost Orin
+role: minor
+status: deceased
+died-in: chapter-09
+`, "# Orin\n");
+    writeMarkdown(path.join(root, "characters", "mara-finn.md"), `
+name: Mara Finn
+role: protagonist
+status: alive
+`, "# Mara\n");
+    writeMarkdown(path.join(root, "characters", "old-tomas.md"), `
+name: Old Tomas
+role: minor
+status: alive
+`, "# Tomas\n");
+    writeMarkdown(path.join(root, "characters", "stray-soul.md"), `
+name: Stray Soul
+role: minor
+status: alive
+`, "# Stray\n");
+    writeMarkdown(path.join(root, "worldbuilding", "locations", "old-mill.md"), `
+name: Old Mill
+type: building
+`, "# Mill\n");
+    writeMarkdown(path.join(root, "worldbuilding", "locations", "elsewhere-lane.md"), `
+name: Elsewhere Lane
+type: street
+`, "# Lane\n");
+
+    writeChapter(root, 1, `
+pov: mara-finn
+locations:
+  - old-mill
+characters:
+  - edran-vale
+  - liv-marsh
+  - mara-finn
+`);
+    writeChapter(root, 2, `
+pov: mara-finn
+locations:
+  - old-mill
+characters:
+  - edran-vale
+`);
+    writeChapter(root, 3, `
+pov: edran-vale
+locations: []
+characters: []
+mentions:
+  - edran-vale
+  - old-tomas
+  - nobody-here
+`);
+    writeChapter(root, 5, `
+pov: mara-finn
+locations: []
+characters:
+  - mara-finn
+`);
+
+    writeMarkdown(path.join(root, "scenes", "chapter-01-scene-01.md"), `
+title: Opening
+chapter: chapter-01
+scene: 1
+pov: mara-finn
+location: old-mill
+characters:
+  - edran-vale
+status: draft
+state-changes: []
+`, "# Opening\n");
+    writeMarkdown(path.join(root, "scenes", "chapter-02-scene-01.md"), `
+title: Aftermath
+chapter: chapter-02
+scene: 1
+pov: edran-vale
+location: elsewhere-lane
+characters:
+  - edran-vale
+status: draft
+state-changes: []
+`, "# Aftermath\n");
+    writeMarkdown(path.join(root, "scenes", "chapter-03-scene-01.md"), `
+title: Memorial
+chapter: chapter-03
+scene: 1
+pov: ""
+location: ""
+characters:
+  - old-tomas
+status: draft
+state-changes: []
+`, "# Memorial\n");
+    writeMarkdown(path.join(root, "scenes", "chapter-05-scene-01.md"), `
+title: Stray
+chapter: chapter-05
+scene: 1
+pov: ""
+location: old-mill
+characters:
+  - stray-soul
+status: draft
+state-changes: []
+`, "# Stray\n");
+    writeMarkdown(path.join(root, "scenes", "chapter-77-scene-01.md"), `
+title: Orphan
+chapter: chapter-77
+scene: 1
+pov: ""
+location: ""
+characters: []
+mentions:
+  - nobody-scene
+status: draft
+state-changes: []
+`, "# Orphan\n");
+
+    writeMarkdown(path.join(root, "continuity", "state.md"), `
+type: continuity-state
+story: deaths
+current-chapter: 0
+`, "# Continuity State\n");
+
+    const result = checkContinuity(scanProject(root));
+    const errors = result.errors.join("\n");
+    const warnings = result.warnings.join("\n");
+
+    expect(result.ok).toBe(false);
+    expect(errors).toContain("characters/liv-marsh.md has died-in chapter-01 but status alive; set status: deceased");
+    expect(errors).toContain("characters/ghost-orin.md died-in references missing chapter chapter-09");
+    expect(errors).toContain("chapters/chapter-02.md lists edran-vale, who died in chapter-01");
+    expect(errors).toContain("chapters/chapter-03.md lists edran-vale, who died in chapter-01");
+    expect(errors).toContain("scenes/chapter-02-scene-01.md lists edran-vale, who died in chapter-01");
+    expect(warnings).toContain("chapters/chapter-03.md POV character edran-vale is not listed in characters");
+    expect(warnings).toContain("scenes/chapter-01-scene-01.md POV character mara-finn is not listed in characters");
+    expect(warnings).toContain("scenes/chapter-05-scene-01.md lists stray-soul but chapters/chapter-05.md does not list them in characters or mentions");
+    expect(warnings).toContain("scenes/chapter-02-scene-01.md is set in elsewhere-lane but chapters/chapter-02.md does not list that location");
+    expect(warnings).toContain("Chapter numbering skips from 3 to 5");
+    expect(warnings).toContain("continuity/state.md current-chapter 0 is behind the latest chapter 5");
+    expect(warnings).not.toContain("chapter-03-scene-01.md lists old-tomas");
+
+    expect(checkProjectContinuity(root).ok).toBe(false);
+    expect(validateProject(root).errors.join("\n")).not.toContain("died-in");
+
+    const links = validateLinks(root).errors.join("\n");
+    expect(links).toContain("chapters/chapter-03.md references missing character nobody-here");
+    expect(links).toContain("scenes/chapter-77-scene-01.md references missing character nobody-scene");
+  });
+
+  test("flags promise, question, completion, and durable state contradictions", () => {
+    const cwd = makeTempDir();
+    const created = createStoryProject({ cwd, title: "Promises", force: false });
+    const root = created.root;
+    fs.writeFileSync(
+      path.join(root, "story.md"),
+      fs.readFileSync(path.join(root, "story.md"), "utf8").replace("status: planning", "status: complete"),
+      "utf8"
+    );
+
+    for (const number of [1, 2, 3, 4]) {
+      writeChapter(root, number, "pov: \"\"\nlocations: []\ncharacters: []");
+    }
+    writeMarkdown(path.join(root, "characters", "kira-snow.md"), `
+name: Kira Snow
+role: protagonist
+status: alive
+`, "# Kira\n");
+    writeMarkdown(path.join(root, "worldbuilding", "locations", "salt-row.md"), `
+name: Salt Row
+type: street
+`, "# Salt Row\n");
+    writeMarkdown(path.join(root, "worldbuilding", "factions", "tide-guild.md"), `
+name: Tide Guild
+type: guild
+status: active
+`, "# Guild\n");
+    writeMarkdown(path.join(root, "worldbuilding", "artifacts", "silver-key.md"), `
+name: Silver Key
+type: object
+status: hidden
+`, "# Key\n");
+
+    writeMarkdown(path.join(root, "continuity", "promises", "long-fuse.md"), `
+title: Long Fuse
+status: planted
+planted: chapter-01
+payoff: ""
+`, "# Long Fuse\n");
+    writeMarkdown(path.join(root, "continuity", "promises", "backwards-payoff.md"), `
+title: Backwards Payoff
+status: paid-off
+planted: chapter-03
+payoff: chapter-02
+`, "# Backwards\n");
+    writeMarkdown(path.join(root, "continuity", "promises", "missing-payoff.md"), `
+title: Missing Payoff
+status: paid-off
+planted: ""
+payoff: ""
+`, "# Missing\n");
+    writeMarkdown(path.join(root, "continuity", "promises", "unrooted-plant.md"), `
+title: Unrooted Plant
+status: planted
+planted: ""
+payoff: ""
+`, "# Unrooted\n");
+    writeMarkdown(path.join(root, "continuity", "promises", "early-record.md"), `
+title: Early Record
+status: planned
+planted: chapter-02
+payoff: ""
+`, "# Early\n");
+
+    writeMarkdown(path.join(root, "continuity", "questions", "reversed.md"), `
+title: Reversed
+status: resolved
+introduced: chapter-03
+resolved: chapter-02
+`, "# Reversed\n");
+    writeMarkdown(path.join(root, "continuity", "questions", "unanchored.md"), `
+title: Unanchored
+status: answered
+introduced: chapter-01
+resolved: ""
+`, "# Unanchored\n");
+    writeMarkdown(path.join(root, "continuity", "questions", "lingering.md"), `
+title: Lingering
+status: open
+introduced: chapter-01
+resolved: chapter-02
+`, "# Lingering\n");
+
+    writeMarkdown(path.join(root, "continuity", "state.md"), `
+type: continuity-state
+story: promises
+current-chapter: 7
+character-state:
+  - loose-note
+  - character: missing-person
+  - character: kira-snow
+    location: nowhere-bay
+  - character: kira-snow
+    location: salt-row
+knowledge-state:
+  - character: ""
+    knows: a secret
+  - character: kira-snow
+    knows: ""
+  - character: kira-snow
+    knows: the key is real
+    learned-in: chapter-09
+object-state:
+  - artifact: ghost-item
+  - artifact: silver-key
+    owner: nobody-known
+  - artifact: silver-key
+    owner: tide-guild
+    location: nowhere-bay
+  - artifact: silver-key
+    owner: kira-snow
+    location: salt-row
+    status: active
+`, "# Continuity State\n");
+
+    const result = checkContinuity(scanProject(root));
+    const errors = result.errors.join("\n");
+    const warnings = result.warnings.join("\n");
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(20);
+    expect(result.warnings).toHaveLength(3);
+    expect(errors).toContain("continuity/promises/backwards-payoff.md pays off in chapter-02 before it is planted in chapter-03");
+    expect(errors).toContain("continuity/promises/missing-payoff.md is paid-off but has no payoff chapter");
+    expect(errors).toContain("continuity/promises/unrooted-plant.md is planted but has no planted chapter");
+    expect(errors).toContain("continuity/questions/reversed.md resolves in chapter-02 before it is introduced in chapter-03");
+    expect(errors).toContain("continuity/questions/unanchored.md is answered but has no resolved chapter");
+    expect(errors).toContain("continuity/questions/lingering.md records resolved chapter chapter-02 but status is still open");
+    expect(errors).toContain("story.md is complete but continuity/promises/long-fuse.md is still planted");
+    expect(errors).toContain("story.md is complete but continuity/promises/early-record.md is still planned");
+    expect(errors).toContain("story.md is complete but continuity/questions/lingering.md is still open");
+    expect(errors).toContain("continuity/state.md current-chapter 7 is ahead of the latest chapter 4");
+    expect(errors).toContain("continuity/state.md character-state[0] must be a mapping");
+    expect(errors).toContain("continuity/state.md character-state[1] references missing character missing-person");
+    expect(errors).toContain("continuity/state.md character-state[2] references missing location nowhere-bay");
+    expect(errors).toContain("continuity/state.md knowledge-state[0] references missing character (unset)");
+    expect(errors).toContain("continuity/state.md knowledge-state[1] is missing knows");
+    expect(errors).toContain("continuity/state.md knowledge-state[2] references missing chapter chapter-09");
+    expect(errors).toContain("continuity/state.md object-state[0] references missing artifact ghost-item");
+    expect(errors).toContain("continuity/state.md object-state[1] references missing owner nobody-known");
+    expect(errors).toContain("continuity/state.md object-state[2] references missing location nowhere-bay");
+    expect(warnings).toContain("continuity/promises/long-fuse.md was planted in chapter-01, 3 chapters ago, and has no payoff yet");
+    expect(warnings).toContain("continuity/promises/early-record.md records planted chapter chapter-02 but status is still planned");
+    expect(warnings).toContain("continuity/state.md object-state[3] status active conflicts with worldbuilding/artifacts/silver-key.md status hidden");
+
+    const actionReport = formatActionReport(projectActions(root));
+    expect(actionReport).toContain("Fix continuity contradictions");
+    expect(actionReport).toContain("Review continuity warnings");
+  });
+
+  test("passes clean projects and skips missing continuity state", () => {
+    const cwd = makeTempDir();
+    const created = createStoryProject({ cwd, title: "Clean", force: false });
+
+    const clean = checkContinuity(scanProject(created.root));
+    expect(clean).toEqual({ ok: true, errors: [], warnings: [] });
+
+    writeMarkdown(path.join(created.root, "characters", "lone-scribe.md"), `
+name: Lone Scribe
+role: protagonist
+status: alive
+`, "# Scribe\n");
+    expect(formatActionReport(projectActions(created.root))).toContain("Project is mechanically healthy");
+
+    fs.rmSync(path.join(created.root, "continuity", "state.md"));
+    expect(checkContinuity(scanProject(created.root)).ok).toBe(true);
+  });
+});

--- a/test/import.test.js
+++ b/test/import.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { extractNameCandidates, importManuscript } from "../src/import.js";
+import { scanProject, validateProject } from "../src/story.js";
+import { makeTempDir } from "./helpers.js";
+
+const PROSE = [
+  "Mara Quill walked The Long Pier at dawn. The gulls followed Mara Quill past the locked door,",
+  "and Mara Quill did not look back along The Long Pier. She asked Harrow for the key, but he said, I think not.",
+  "Old Harrow laughed on The Long Pier, so they paid Harrow in salt and told Harrow nothing more.",
+  "It was over. And Then he ran."
+].join(" ");
+
+describe("manuscript import", () => {
+  test("imports a manuscript file split on chapter headings", () => {
+    const cwd = makeTempDir();
+    fs.writeFileSync(path.join(cwd, "book.md"), [
+      "---",
+      "title: Old Export",
+      "---",
+      "# The Lost Coast",
+      "",
+      "A short preface paragraph.",
+      "",
+      "## Chapter 1: The Door",
+      "",
+      PROSE,
+      "",
+      "## Chapter 2 — Smoke",
+      "",
+      "Smoke rolled in over the harbor wall.",
+      "",
+      "### Chapter IV: Storm",
+      "",
+      "The storm arrived without a bell."
+    ].join("\n"), "utf8");
+
+    const result = importManuscript({ source: "book.md", title: "The Lost Coast", cwd });
+
+    expect(result.storyId).toBe("the-lost-coast");
+    expect(result.chapters).toBe(4);
+    expect(result.words).toBeGreaterThan(60);
+
+    const project = scanProject(result.root);
+    expect(project.chapters.map((chapter) => chapter.title)).toEqual(["Opening", "The Door", "Smoke", "Storm"]);
+    expect(project.chapters.map((chapter) => chapter.number)).toEqual([1, 2, 3, 4]);
+    expect(project.chapters[1].declaredWordCount).toBe(project.chapters[1].wordCount);
+    expect(fs.readFileSync(path.join(result.root, "chapters", "_index.md"), "utf8")).toContain("chapter-04");
+    expect(validateProject(result.root).ok).toBe(true);
+
+    const names = result.candidates.map((candidate) => candidate.name);
+    expect(result.candidates).toContainEqual({ name: "Mara Quill", count: 3 });
+    expect(result.candidates).toContainEqual({ name: "Long Pier", count: 3 });
+    expect(result.candidates).toContainEqual({ name: "Harrow", count: 3 });
+    expect(names).not.toContain("I");
+    expect(names).not.toContain("Old Harrow");
+  });
+
+  test("imports a directory of chapter files", () => {
+    const cwd = makeTempDir();
+    const source = path.join(cwd, "drafts");
+    fs.mkdirSync(source);
+    fs.writeFileSync(path.join(source, "01-the-door.md"), "# The Door\n\nThe door would not open.", "utf8");
+    fs.writeFileSync(path.join(source, "02-smoke.txt"), "Smoke rolled in without a heading.", "utf8");
+    fs.writeFileSync(path.join(source, "notes.json"), "{}", "utf8");
+
+    const result = importManuscript({ source: "drafts", title: "Door And Smoke", cwd, dir: "imported" });
+
+    expect(result.root).toBe(path.join(cwd, "imported"));
+    expect(result.chapters).toBe(2);
+    const project = scanProject(result.root);
+    expect(project.chapters.map((chapter) => chapter.title)).toEqual(["The Door", "02 Smoke"]);
+  });
+
+  test("rejects missing sources and empty content", () => {
+    const cwd = makeTempDir();
+    expect(() => importManuscript({ cwd, title: "X" })).toThrow("An import source file or directory is required");
+    expect(() => importManuscript({ cwd, source: "missing.md", title: "X" })).toThrow("Import source not found");
+
+    const emptyDir = path.join(cwd, "empty");
+    fs.mkdirSync(emptyDir);
+    expect(() => importManuscript({ cwd, source: "empty", title: "X" })).toThrow("No markdown or text files found");
+
+    fs.writeFileSync(path.join(cwd, "blank.md"), "---\ntitle: Blank\n---\n", "utf8");
+    expect(() => importManuscript({ cwd, source: "blank.md", title: "X" })).toThrow("No chapter content found in import source");
+  });
+
+  test("extracts candidates deterministically", () => {
+    expect(extractNameCandidates("plain prose with no names at all")).toEqual([]);
+    const repeated = "He met Vex Marrow today. She trusted Vex Marrow once. They feared Vex Marrow forever.";
+    expect(extractNameCandidates(repeated)).toEqual([{ name: "Vex Marrow", count: 3 }]);
+  });
+});

--- a/test/story.test.js
+++ b/test/story.test.js
@@ -628,6 +628,7 @@ word-count: 1
       title: "Empty",
       validation: { ok: true, errors: [], warnings: [] },
       links: { ok: true, errors: [], warnings: [] },
+      continuity: { ok: true, errors: [], warnings: [] },
       actions: []
     })).toContain("No actions found");
 


### PR DESCRIPTION
- New src/continuity.js: deterministic continuity checks wired into a new
  'story continuity' command and folded into doctor, report, and next.
  Catches dead characters appearing after their died-in chapter, payoffs
  before plants, questions resolved before introduced, unfired Chekhov
  promises, POV/cast mismatches, chapter numbering gaps, completion-state
  contradictions, and broken continuity/state.md references.
- New schema fields: optional character died-in, and chapter/scene mentions
  for posthumous or flashback references that should stay legal.
- New src/import.js: 'story import' splits an existing manuscript (file or
  directory) into a new project with accurate word counts and registries,
  and prints recurring proper-name candidates for bible building.
- New examples/the-unraveled-thread: deliberately broken project whose
  exact findings are asserted by check-examples.js, doubling as the README
  demo and a regression test. Harbor example enriched with populated
  continuity state, a planted promise, and an open question.
- New templates/github: story-checks.yml CI for story repos and
  draft-next-chapter.yml for writing a book via scheduled chapter PRs.
- CLI failure summaries now use a failure message instead of repeating the
  success message. Docs, skills, JSON schema updated; version 0.3.0.

https://claude.ai/code/session_01XVwAnE2xRMVd7CZR4MrSU1