### PR TITLE
Allow chapter 0 so a prologue can be a chapter

### DIFF
--- a/skills/story-maintenance/scripts/story.js
+++ b/skills/story-maintenance/scripts/story.js
@@ -2524,14 +2524,14 @@ function validateChapters(project, errors) {
     if (data["word-count"] !== undefined) {
       requireInteger(data, "word-count", label, errors);
     }
-    if (filenameNumber === 0) {
+    if (filenameNumber === null) {
       errors.push(`${label} filename must match chapter-{NN}.md`);
     } else if (Number.isInteger(data.number) && data.number !== filenameNumber) {
       errors.push(`${label} number must match filename chapter number ${filenameNumber}`);
     }
     if (Number.isInteger(data.number)) {
-      if (data.number <= 0) {
-        errors.push(`${label} number must be greater than 0`);
+      if (data.number < 0) {
+        errors.push(`${label} number must not be negative`);
       }
       const existing = seenNumbers.get(data.number);
       if (existing) {
@@ -2721,7 +2721,7 @@ function requireFields(data, fields, label, errors) {
 }
 function chapterNumberFromFile(file) {
   const match = /chapter-(\d+)/.exec(path2.basename(file));
-  return match ? Number.parseInt(match[1], 10) : 0;
+  return match ? Number.parseInt(match[1], 10) : null;
 }
 function relative2(project, file) {
   return path2.relative(project.root, file);

--- a/src/story.js
+++ b/src/story.js
@@ -2357,15 +2357,15 @@ function validateChapters(project, errors) {
       requireInteger(data, "word-count", label, errors);
     }
 
-    if (filenameNumber === 0) {
+    if (filenameNumber === null) {
       errors.push(`${label} filename must match chapter-{NN}.md`);
     } else if (Number.isInteger(data.number) && data.number !== filenameNumber) {
       errors.push(`${label} number must match filename chapter number ${filenameNumber}`);
     }
 
     if (Number.isInteger(data.number)) {
-      if (data.number <= 0) {
-        errors.push(`${label} number must be greater than 0`);
+      if (data.number < 0) {
+        errors.push(`${label} number must not be negative`);
       }
 
       const existing = seenNumbers.get(data.number);
@@ -2582,7 +2582,7 @@ function requireFields(data, fields, label, errors) {
 
 function chapterNumberFromFile(file) {
   const match = /chapter-(\d+)/.exec(path.basename(file));
-  return match ? Number.parseInt(match[1], 10) : 0;
+  return match ? Number.parseInt(match[1], 10) : null;
 }
 
 function relative(project, file) {

--- a/test/story.test.js
+++ b/test/story.test.js
@@ -570,8 +570,8 @@ word-count: 1
     expect(validation.errors.join("\n")).toContain("characters/Bad Name.md relationship to missing-person is missing type");
     expect(validation.errors.join("\n")).toContain("characters/bad-relationships.md frontmatter field relationships must be a list");
     expect(validation.errors.join("\n")).toContain("worldbuilding/systems/bad-system.md frontmatter field prevalence must be a scalar");
-    expect(validation.errors.join("\n")).toContain("chapters/chapter-00.md filename must match chapter-{NN}.md");
-    expect(validation.errors.join("\n")).toContain("chapters/chapter-00.md number must be greater than 0");
+    expect(validation.errors.join("\n")).not.toContain("chapters/chapter-00.md filename must match chapter-{NN}.md");
+    expect(validation.errors.join("\n")).not.toContain("chapters/chapter-00.md number must not be negative");
     expect(validation.errors.join("\n")).toContain("chapters/chapter-01.md frontmatter field status has unsupported value invalid");
     expect(validation.errors.join("\n")).toContain("chapters/chapter-01.md frontmatter field word-count must be an integer");
     expect(validation.errors.join("\n")).toContain("chapters/chapter-01.md number must match filename chapter number 1");


### PR DESCRIPTION
A prologue stored as `chapters/chapter-00.md` with `number: 0` cannot pass `story validate`, though it works correctly everywhere else in the toolchain.

## Cause

`chapterNumberFromFile` uses `0` as its "no number in this filename" sentinel:

```js
return match ? Number.parseInt(match[1], 10) : 0;
```

So `chapter-00.md` is indistinguishable from a filename with no number at all, and `validateChapters` rejects it as malformed. A second rule then rejects `number: 0` on its own.

## Why chapter 0 is otherwise fine

Chapters sort by `left.number - right.number`, so a prologue at 0 leads the manuscript correctly. On a project with a prologue plus 12 chapters, `story export` emits all 13 in the right order and `story wordcount` counts the prologue. Validation is the only thing that refuses it.

## Change

- `chapterNumberFromFile` returns `null` when the filename has no number, so a genuinely malformed name (`notanumber.md`) still produces `filename must match chapter-{NN}.md`.
- The number check rejects negatives instead of zero, and its message changes to `number must not be negative`.
- Bundle rebuilt via `build:fallback`; `check:fallback` passes.

## Note on intent

The existing test asserted that `chapter-00.md` produces both errors, so this is a deliberate change of behaviour rather than a pure bug fix — I've updated that test to assert the opposite. If prologues are meant to live outside `chapters/`, this PR is the wrong fix and I'd rather know; the alternative I found is worse, since `exportManuscript` iterates `project.chapters` and a prologue moved out is silently dropped from the manuscript.

`bun test`: 60 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)